### PR TITLE
A good example for vue part

### DIFF
--- a/zh-CN/guide/console/extension.md
+++ b/zh-CN/guide/console/extension.md
@@ -42,7 +42,9 @@ export default (ctx: Context) => {
 
 ```vue title=client/custom-page.vue
 <template>
-  <k-card>扩展内容</k-card>
+    <k-layout>
+        <k-card>扩展内容</k-card>
+    </k-layout>
 </template>
 ```
 


### PR DESCRIPTION
```
<template>
    <k-layout>
        <k-card>扩展内容</k-card>
    </k-layout>
</template>
```

is better than

```
<template>
   <k-card>扩展内容</k-card>
</template>
```

with layout introduction