### PR TITLE
`required()` 可能会导致 union 行为异常

### DIFF
--- a/zh-CN/schema/advanced/union-select.md
+++ b/zh-CN/schema/advanced/union-select.md
@@ -27,5 +27,5 @@ export default Schema.object({
 ```
 
 ::: tip
-请不要对其使用 `required()`，这可能会导致行为的异常。
+通常情况下，请不要对其使用 `required()`，这可能会导致行为异常。
 :::

--- a/zh-CN/schema/advanced/union-select.md
+++ b/zh-CN/schema/advanced/union-select.md
@@ -25,3 +25,7 @@ export default Schema.object({
   ]).role('radio'),
 })
 ```
+
+::: tip
+请不要对其使用 `required()`，这可能会导致行为的异常。
+:::


### PR DESCRIPTION
https://github.com/idanran/myrtus/blob/556a42e4e314b43cbea96c11aeb2eb0d6e2fa5d9/plugins/forward/src/index.ts#L235

在以上链接中，由于 `Schema.union(platform).required()`，导致“配置联动”无法展开。