### PR TITLE
clarify `路径` instead of `目录`

### DIFF
--- a/zh-CN/manual/starter/boilerplate.md
+++ b/zh-CN/manual/starter/boilerplate.md
@@ -84,7 +84,7 @@ yarn config set registry https://registry.npmmirror.com
 打开命令行，并进入你想要创建 Koishi 项目的目录。
 
 ::: tip
-这个目录不宜过长，且路径中请避免出现中文或者空格。我们推荐的目录如下：
+这个路径不宜过长，避免出现中文或者空格。我们推荐的路径如下：
 
 - Windows：`C:\dev` 或者 `D:\dev` (也不要直接在盘根创建项目，最好是建一层目录)
 - 其他操作系统：`~/dev`

--- a/zh-CN/manual/starter/boilerplate.md
+++ b/zh-CN/manual/starter/boilerplate.md
@@ -84,7 +84,7 @@ yarn config set registry https://registry.npmmirror.com
 打开命令行，并进入你想要创建 Koishi 项目的目录。
 
 ::: tip
-这个路径不宜过长，避免出现中文或者空格。我们推荐的路径如下：
+这个路径不宜过长，且应当避免出现中文或者空格。我们推荐的路径如下：
 
 - Windows：`C:\dev` 或者 `D:\dev` (也不要直接在盘根创建项目，最好是建一层目录)
 - 其他操作系统：`~/dev`


### PR DESCRIPTION
Another concern is that should we also clarify the `Command Prompt` or `Terminal`, now it is just `命令行` (command line). Consider change it to `Terminal` as well?