### PR TITLE
Update config.md: use .env.local instead of .env

### DIFF
--- a/zh-CN/guide/develop/config.md
+++ b/zh-CN/guide/develop/config.md
@@ -133,7 +133,7 @@ plugins:
 
 当项目启动时，会将环境变量中的值替换进去。
 
-除了系统提供的环境变量外，Koishi 还原生支持 [dotenv](https://github.com/motdotla/dotenv)。你可以在当前目录创建一个 `.env` 文件，并在里面填写你的环境变量。这个文件已经被包含在 `.gitignore` 中，你可以在其中填写隐私信息 (例如账号密码) 而不用担心被上传到远端。例如在上面的例子中你就可以这样写：
+除了系统提供的环境变量外，Koishi 还原生支持 [dotenv](https://github.com/motdotla/dotenv)。你可以在当前目录创建一个 `.env.local` 文件，并在里面填写你的环境变量。这个文件已经被包含在 `.gitignore` 中，你可以在其中填写隐私信息 (例如账号密码) 而不用担心被上传到远端。例如在上面的例子中你就可以这样写：
 
 ```sh title=.env
 DISCORD_TOKEN = xxx


### PR DESCRIPTION
it looks like `.env` is no longer included in the `.gitignore` file, and instead `.env.local` is included

I guess using `.env.local` is recommended