### PR TITLE
Fix member.md

### DIFF
--- a/zh-CN/api/resources/member.md
+++ b/zh-CN/api/resources/member.md
@@ -45,7 +45,7 @@ interface GuildMember {
 
 将某个用户踢出群组。
 
-### bot.muteGuildMember(guildId, userId, duration?, reason?) <badge type="warning">实验性</badge>
+### bot.muteGuildMember(guildId, userId, duration, reason?) <badge type="warning">实验性</badge>
 
 - **guildId:** `string` 群组 ID
 - **userId:** `string` 用户 ID


### PR DESCRIPTION
bot.muteGuildMember 的 duration 参数并非可选