### PR TITLE
Patch ：配置构型缺失date页面

### DIFF
--- a/.vitepress/config/de-DE.json
+++ b/.vitepress/config/de-DE.json
@@ -967,6 +967,10 @@
               "link": "/schema/basic/boolean.md"
             },
             {
+              "text": "日期 (Date)",
+              "link": "/schema/basic/date.md"
+            },
+            {
               "text": "位集 (Bitset)",
               "link": "/schema/basic/bitset.md"
             },

--- a/.vitepress/config/en-US.json
+++ b/.vitepress/config/en-US.json
@@ -967,6 +967,10 @@
               "link": "/schema/basic/boolean.md"
             },
             {
+              "text": "Date",
+              "link": "/schema/basic/date.md"
+            },
+            {
               "text": "Bitset",
               "link": "/schema/basic/bitset.md"
             },

--- a/.vitepress/config/fr-FR.json
+++ b/.vitepress/config/fr-FR.json
@@ -967,6 +967,10 @@
               "link": "/schema/basic/boolean.md"
             },
             {
+              "text": "Date : Date",
+              "link": "/schema/basic/date.md"
+            },
+            {
               "text": "Bitset : Stockage binaire",
               "link": "/schema/basic/bitset.md"
             },

--- a/.vitepress/config/ja-JP.json
+++ b/.vitepress/config/ja-JP.json
@@ -967,6 +967,10 @@
               "link": "/schema/basic/boolean.md"
             },
             {
+              "text": "日期 (Date)",
+              "link": "/schema/basic/date.md"
+            },
+            {
               "text": "位集 (Bitset)",
               "link": "/schema/basic/bitset.md"
             },

--- a/.vitepress/config/ru-RU.json
+++ b/.vitepress/config/ru-RU.json
@@ -967,6 +967,10 @@
               "link": "/schema/basic/boolean.md"
             },
             {
+              "text": "日期 (Date)",
+              "link": "/schema/basic/date.md"
+            },
+            {
               "text": "位集 (Bitset)",
               "link": "/schema/basic/bitset.md"
             },

--- a/.vitepress/config/zh-CN.json
+++ b/.vitepress/config/zh-CN.json
@@ -697,6 +697,9 @@
           "text": "布尔值 (Boolean)",
           "link": "/schema/basic/boolean.md"
         }, {
+          "text": "日期 (Date)",
+          "link": "/schema/basic/date.md"
+        }, {
           "text": "位集 (Bitset)",
           "link": "/schema/basic/bitset.md"
         }, {

--- a/.vitepress/config/zh-CN.json
+++ b/.vitepress/config/zh-CN.json
@@ -1,27 +1,9 @@
 {
   "description": "创建跨平台、可扩展、高性能的机器人",
   "head": [
-    [
-      "link",
-      {
-        "rel": "icon",
-        "href": "/logo.png"
-      }
-    ],
-    [
-      "link",
-      {
-        "rel": "manifest",
-        "href": "/manifest/zh-CN.json"
-      }
-    ],
-    [
-      "meta",
-      {
-        "name": "theme-color",
-        "content": "#5546a3"
-      }
-    ]
+    ["link", { "rel": "icon", "href": "/logo.png" }],
+    ["link", { "rel": "manifest", "href": "/manifest/zh-CN.json" }],
+    ["meta", { "name": "theme-color", "content": "#5546a3" }]
   ],
   "themeConfig": {
     "editLink": {
@@ -29,1176 +11,845 @@
       "pattern": "https://github.com/koishijs/docs/edit/main/:path"
     },
     "navText": "导航",
-    "nav": [
-      {
-        "text": "入门",
-        "link": "/manual/introduction.md",
-        "activeMatch": "/manual/"
-      },
-      {
-        "text": "开发",
-        "items": [
-          {
-            "text": "开发指南",
-            "link": "/guide/"
-          },
-          {
-            "text": "进阶指南",
-            "link": "/cookbook/"
-          },
-          {
-            "text": "API 参考",
-            "link": "/api/"
-          },
-          {
-            "text": "演练场：配置构型",
-            "link": "/schema/"
-          }
-        ],
-        "activeMatch": "/(guide|api|schema|cookbook)/"
-      },
-      {
-        "text": "插件",
-        "items": [
-          {
-            "text": "插件市场",
-            "link": "/market/"
-          },
-          {
-            "text": "官方插件一览",
-            "link": "/plugins/"
-          }
-        ],
-        "activeMatch": "/(plugins|market)/"
-      },
-      {
-        "text": "更多",
-        "items": [
-          {
-            "text": "参与讨论",
-            "link": "/about/contact.md"
-          },
-          {
-            "text": "社区资源",
-            "link": "/about/community.md"
-          },
-          {
-            "text": "各版本介绍",
-            "link": "/releases/index.md"
-          }
-        ],
-        "activeMatch": "/(about|releases)/"
-      }
-    ],
+    "nav": [{
+      "text": "入门",
+      "link": "/manual/introduction.md",
+      "activeMatch": "/manual/"
+    }, {
+      "text": "开发",
+      "items": [{
+        "text": "开发指南",
+        "link": "/guide/"
+      }, {
+        "text": "进阶指南",
+        "link": "/cookbook/"
+      }, {
+        "text": "API 参考",
+        "link": "/api/"
+      }, {
+        "text": "演练场：配置构型",
+        "link": "/schema/"
+      }],
+      "activeMatch": "/(guide|api|schema|cookbook)/"
+    }, {
+      "text": "插件",
+      "items": [{
+        "text": "插件市场",
+        "link": "/market/"
+      }, {
+        "text": "官方插件一览",
+        "link": "/plugins/"
+      }],
+      "activeMatch": "/(plugins|market)/"
+    }, {
+      "text": "更多",
+      "items": [{
+        "text": "参与讨论",
+        "link": "/about/contact.md"
+      }, {
+        "text": "社区资源",
+        "link": "/about/community.md"
+      }, {
+        "text": "各版本介绍",
+        "link": "/releases/index.md"
+      }],
+      "activeMatch": "/(about|releases)/"
+    }],
     "sidebar": {
-      "/manual/": [
-        {
-          "text": "",
-          "items": [
-            {
-              "text": "介绍",
-              "link": "/manual/introduction.md"
-            }
-          ]
-        },
-        {
-          "text": "",
-          "items": [
-            {
-              "text": "安装",
-              "link": "/manual/starter/"
-            },
-            {
-              "text": "为 Windows 安装",
-              "link": "/manual/starter/windows.md"
-            },
-            {
-              "text": "为 macOS 安装",
-              "link": "/manual/starter/macos.md"
-            },
-            {
-              "text": "为 Linux 安装",
-              "link": "/manual/starter/linux.md"
-            },
-            {
-              "text": "为 Android 安装",
-              "link": "/manual/starter/android.md"
-            },
-            {
-              "text": "在容器中使用",
-              "link": "/manual/starter/docker.md"
-            },
-            {
-              "text": "创建模板项目",
-              "link": "/manual/starter/boilerplate.md"
-            },
-            {
-              "text": "作为依赖调用",
-              "link": "/manual/starter/direct.md"
-            }
-          ]
-        },
-        {
-          "text": "使用",
-          "items": [
-            {
-              "text": "安装和配置插件",
-              "link": "/manual/usage/market.md"
-            },
-            {
-              "text": "第一次对话",
-              "link": "/manual/usage/adapter.md"
-            },
-            {
-              "text": "指令系统",
-              "link": "/manual/usage/command.md"
-            },
-            {
-              "text": "账号登录与绑定",
-              "link": "/manual/usage/platform.md"
-            },
-            {
-              "text": "深入定制机器人",
-              "link": "/manual/usage/customize.md"
-            }
-          ]
-        },
-        {
-          "text": "配方",
-          "items": [
-            {
-              "text": "指令进阶技巧",
-              "link": "/manual/recipe/execution.md"
-            },
-            {
-              "text": "维护多份配置",
-              "link": "/manual/recipe/multiple.md"
-            },
-            {
-              "text": "搜索插件市场",
-              "link": "/manual/recipe/search.md"
-            },
-            {
-              "text": "公网部署",
-              "link": "/manual/recipe/server.md"
-            }
-          ]
-        },
-        {
-          "text": "启动器",
-          "items": [
-            {
-              "text": "系统要求",
-              "link": "/manual/launcher/system.md"
-            },
-            {
-              "text": "命令行工具",
-              "link": "/manual/launcher/cli.md"
-            }
-          ]
-        }
-      ],
-      "/guide/": [
-        {
-          "text": "",
-          "items": [
-            {
-              "text": "总览",
-              "link": "/guide/"
-            }
-          ]
-        },
-        {
-          "text": "开发起步",
-          "items": [
-            {
-              "text": "环境搭建",
-              "link": "/guide/develop/setup.md"
-            },
-            {
-              "text": "配置文件",
-              "link": "/guide/develop/config.md"
-            },
-            {
-              "text": "启动脚本",
-              "link": "/guide/develop/script.md"
-            },
-            {
-              "text": "工作区开发",
-              "link": "/guide/develop/workspace.md"
-            },
-            {
-              "text": "发布插件",
-              "link": "/guide/develop/publish.md"
-            }
-          ]
-        },
-        {
-          "text": "交互基础",
-          "items": [
-            {
-              "text": "指令开发",
-              "link": "/guide/basic/command.md"
-            },
-            {
-              "text": "事件系统",
-              "link": "/guide/basic/events.md"
-            },
-            {
-              "text": "中间件",
-              "link": "/guide/basic/middleware.md"
-            },
-            {
-              "text": "消息元素",
-              "link": "/guide/basic/element.md"
-            },
-            {
-              "text": "进阶用法",
-              "link": "/guide/basic/advanced.md"
-            }
-          ]
-        },
-        {
-          "text": "模块化",
-          "items": [
-            {
-              "text": "认识插件",
-              "link": "/guide/plugin/"
-            },
-            {
-              "text": "配置构型",
-              "link": "/guide/plugin/schema.md"
-            },
-            {
-              "text": "生命周期",
-              "link": "/guide/plugin/lifecycle.md"
-            },
-            {
-              "text": "服务与依赖",
-              "link": "/guide/plugin/service.md"
-            },
-            {
-              "text": "过滤器",
-              "link": "/guide/plugin/filter.md"
-            }
-          ]
-        },
-        {
-          "text": "数据库",
-          "items": [
-            {
-              "text": "基本用法",
-              "link": "/guide/database/"
-            },
-            {
-              "text": "数据模型",
-              "link": "/guide/database/model.md"
-            },
-            {
-              "text": "进阶查询技巧",
-              "link": "/guide/database/selection.md"
-            },
-            {
-              "text": "内置数据结构",
-              "link": "/guide/database/builtin.md"
-            },
-            {
-              "text": "权限管理",
-              "link": "/guide/database/permission.md"
-            }
-          ]
-        },
-        {
-          "text": "跨平台",
-          "items": [
-            {
-              "text": "基础知识",
-              "link": "/guide/adapter/index.md"
-            },
-            {
-              "text": "实现机器人",
-              "link": "/guide/adapter/bot.md"
-            },
-            {
-              "text": "实现适配器",
-              "link": "/guide/adapter/adapter.md"
-            },
-            {
-              "text": "消息编码",
-              "link": "/guide/adapter/message.md"
-            },
-            {
-              "text": "平台集成",
-              "link": "/guide/adapter/integration.md"
-            }
-          ]
-        },
-        {
-          "text": "控制台",
-          "items": [
-            {
-              "text": "扩展控制台",
-              "link": "/guide/console/index.md"
-            },
-            {
-              "text": "数据交互",
-              "link": "/guide/console/data.md"
-            },
-            {
-              "text": "客户端开发",
-              "link": "/guide/console/client.md"
-            },
-            {
-              "text": "主题开发",
-              "link": "/guide/console/theme.md"
-            }
-          ]
-        },
-        {
-          "text": "国际化",
-          "items": [
-            {
-              "text": "基本用法",
-              "link": "/guide/i18n/index.md"
-            },
-            {
-              "text": "本地化文件",
-              "link": "/guide/i18n/translation.md"
-            },
-            {
-              "text": "语言包开发",
-              "link": "/guide/i18n/lang-pack.md"
-            },
-            {
-              "text": "接入 Crowdin",
-              "link": "/guide/i18n/crowdin.md"
-            }
-          ]
-        },
-        {
-          "items": [
-            {
-              "text": "→ 进阶指南",
-              "link": "/cookbook/"
-            }
-          ]
-        }
-      ],
-      "/api/": [
-        {
-          "text": "",
-          "items": [
-            {
-              "text": "总览",
-              "link": "/api/"
-            },
-            {
-              "text": "术语表",
-              "link": "/api/glossary.md"
-            }
-          ]
-        },
-        {
-          "text": "演练场",
-          "desc": "我们专门为一些 API 提供了交互式的演练场。",
-          "items": [
-            {
-              "text": "配置构型",
-              "link": "/schema/"
-            }
-          ]
-        },
-        {
-          "text": "核心模块",
-          "items": [
-            {
-              "text": "适配器 (Adapter)",
-              "link": "/api/core/adapter.md"
-            },
-            {
-              "text": "应用 (App)",
-              "link": "/api/core/app.md"
-            },
-            {
-              "text": "机器人 (Bot)",
-              "link": "/api/core/bot.md"
-            },
-            {
-              "text": "指令 (Command)",
-              "link": "/api/core/command.md"
-            },
-            {
-              "text": "上下文 (Context)",
-              "link": "/api/core/context.md"
-            },
-            {
-              "text": "事件 (Events)",
-              "link": "/api/core/events.md"
-            },
-            {
-              "text": "会话 (Session)",
-              "link": "/api/core/session.md"
-            }
-          ]
-        },
-        {
-          "text": "内置服务",
-          "items": [
-            {
-              "text": "事件系统 (Events)",
-              "link": "/api/service/events.md"
-            },
-            {
-              "text": "过滤器 (Filter)",
-              "link": "/api/service/filter.md"
-            },
-            {
-              "text": "网络请求 (HTTP)",
-              "link": "/api/service/http.md"
-            },
-            {
-              "text": "国际化 (I18n)",
-              "link": "/api/service/i18n.md"
-            },
-            {
-              "text": "加载器 (Loader)",
-              "link": "/api/service/loader.md"
-            },
-            {
-              "text": "权限管理 (Permissions)",
-              "link": "/api/service/permissions.md"
-            },
-            {
-              "text": "插件系统 (Registry)",
-              "link": "/api/service/registry.md"
-            },
-            {
-              "text": "服务器 (Server)",
-              "link": "/api/service/server.md"
-            },
-            {
-              "text": "计时器 (Timer)",
-              "link": "/api/service/timer.md"
-            }
-          ]
-        },
-        {
-          "text": "平台资源",
-          "items": [
-            {
-              "text": "频道 (Channel)",
-              "link": "/api/resources/channel.md"
-            },
-            {
-              "text": "群组 (Guild)",
-              "link": "/api/resources/guild.md"
-            },
-            {
-              "text": "群组成员 (GuildMember)",
-              "link": "/api/resources/member.md"
-            },
-            {
-              "text": "群组角色 (GuildRole)",
-              "link": "/api/resources/role.md"
-            },
-            {
-              "text": "交互 (Interaction)",
-              "link": "/api/resources/interaction.md"
-            },
-            {
-              "text": "登录状态 (Login)",
-              "link": "/api/resources/login.md"
-            },
-            {
-              "text": "消息 (Message)",
-              "link": "/api/resources/message.md"
-            },
-            {
-              "text": "表态 (Reaction)",
-              "link": "/api/resources/reaction.md"
-            },
-            {
-              "text": "用户 (User)",
-              "link": "/api/resources/user.md"
-            }
-          ]
-        },
-        {
+      "/manual/": [{
+        "text": "",
+        "items": [{
+          "text": "介绍",
+          "link": "/manual/introduction.md"
+        }]
+      }, {
+        "text": "",
+        "items": [{
+          "text": "安装",
+          "link": "/manual/starter/"
+        }, {
+          "text": "为 Windows 安装",
+          "link": "/manual/starter/windows.md"
+        }, {
+          "text": "为 macOS 安装",
+          "link": "/manual/starter/macos.md"
+        }, {
+          "text": "为 Linux 安装",
+          "link": "/manual/starter/linux.md"
+        }, {
+          "text": "为 Android 安装",
+          "link": "/manual/starter/android.md"
+        }, {
+          "text": "在容器中使用",
+          "link": "/manual/starter/docker.md"
+        }, {
+          "text": "创建模板项目",
+          "link": "/manual/starter/boilerplate.md"
+        }, {
+          "text": "作为依赖调用",
+          "link": "/manual/starter/direct.md"
+        }]
+      }, {
+        "text": "使用",
+        "items": [{
+          "text": "安装和配置插件",
+          "link": "/manual/usage/market.md"
+        }, {
+          "text": "第一次对话",
+          "link": "/manual/usage/adapter.md"
+        }, {
+          "text": "指令系统",
+          "link": "/manual/usage/command.md"
+        }, {
+          "text": "账号登录与绑定",
+          "link": "/manual/usage/platform.md"
+        }, {
+          "text": "深入定制机器人",
+          "link": "/manual/usage/customize.md"
+        }]
+      }, {
+        "text": "配方",
+        "items": [{
+          "text": "指令进阶技巧",
+          "link": "/manual/recipe/execution.md"
+        }, {
+          "text": "维护多份配置",
+          "link": "/manual/recipe/multiple.md"
+        }, {
+          "text": "搜索插件市场",
+          "link": "/manual/recipe/search.md"
+        }, {
+          "text": "公网部署",
+          "link": "/manual/recipe/server.md"
+        }]
+      }, {
+        "text": "启动器",
+        "items": [{
+          "text": "系统要求",
+          "link": "/manual/launcher/system.md"
+        }, {
+          "text": "命令行工具",
+          "link": "/manual/launcher/cli.md"
+        }]
+      }],
+      "/guide/": [{
+        "text": "",
+        "items": [{
+          "text": "总览",
+          "link": "/guide/"
+        }]
+      }, {
+        "text": "开发起步",
+        "items": [{
+          "text": "环境搭建",
+          "link": "/guide/develop/setup.md"
+        }, {
+          "text": "配置文件",
+          "link": "/guide/develop/config.md"
+        }, {
+          "text": "启动脚本",
+          "link": "/guide/develop/script.md"
+        }, {
+          "text": "工作区开发",
+          "link": "/guide/develop/workspace.md"
+        }, {
+          "text": "发布插件",
+          "link": "/guide/develop/publish.md"
+        }]
+      }, {
+        "text": "交互基础",
+        "items": [{
+          "text": "指令开发",
+          "link": "/guide/basic/command.md"
+        }, {
+          "text": "事件系统",
+          "link": "/guide/basic/events.md"
+        }, {
+          "text": "中间件",
+          "link": "/guide/basic/middleware.md"
+        }, {
           "text": "消息元素",
-          "items": [
-            {
-              "text": "语法规范",
-              "link": "/api/message/syntax.md"
-            },
-            {
-              "text": "标准元素",
-              "link": "/api/message/elements.md"
-            },
-            {
-              "text": "内置组件",
-              "link": "/api/message/components.md"
-            },
-            {
-              "text": "渲染函数",
-              "link": "/api/message/api.md"
-            },
-            {
-              "text": "消息编码器",
-              "link": "/api/message/encoder.md"
-            }
-          ]
-        },
-        {
-          "text": "数据库",
-          "items": [
-            {
-              "text": "数据模型 (Model)",
-              "link": "/api/database/model.md"
-            },
-            {
-              "text": "数据库操作 (Database)",
-              "link": "/api/database/database.md"
-            },
-            {
-              "text": "查询表达式 (Query)",
-              "link": "/api/database/query.md"
-            },
-            {
-              "text": "求值表达式 (Eval)",
-              "link": "/api/database/evaluation.md"
-            },
-            {
-              "text": "查询构造器 (Selection)",
-              "link": "/api/database/selection.md"
-            },
-            {
-              "text": "内置数据结构",
-              "link": "/api/database/built-in.md"
-            }
-          ]
-        },
-        {
-          "text": "控制台",
-          "items": [
-            {
-              "text": "服务端 API",
-              "link": "/api/console/server.md"
-            },
-            {
-              "text": "上下文 API",
-              "link": "/api/console/context.md"
-            },
-            {
-              "text": "组合式 API",
-              "link": "/api/console/composition.md"
-            },
-            {
-              "text": "内置组件",
-              "link": "/api/console/component.md"
-            }
-          ]
-        },
-        {
-          "text": "其他功能",
-          "items": [
-            {
-              "text": "观察者 (Observer)",
-              "link": "/api/utils/observer.md"
-            },
-            {
-              "text": "输出日志 (Logger)",
-              "link": "/api/utils/logger.md"
-            },
-            {
-              "text": "随机操作 (Random)",
-              "link": "/api/utils/random.md"
-            },
-            {
-              "text": "其他工具 (Misc)",
-              "link": "/api/utils/misc.md"
-            }
-          ]
-        }
-      ],
-      "/cookbook/": [
-        {
-          "items": [
-            {
-              "text": "总览",
-              "link": "/cookbook/"
-            }
-          ]
-        },
-        {
-          "text": "设计原理",
-          "items": [
-            {
-              "text": "项目架构",
-              "link": "/cookbook/design/structure.md"
-            },
-            {
-              "text": "可逆的插件系统",
-              "link": "/cookbook/design/disposable.md"
-            },
-            {
-              "text": "从元框架到框架",
-              "link": "/cookbook/design/framework.md"
-            },
-            {
-              "text": "零占用的存储",
-              "link": "/cookbook/design/storage.md"
-            },
-            {
-              "text": "深入工作区",
-              "link": "/cookbook/design/workspace.md"
-            }
-          ]
-        },
-        {
-          "text": "最佳实践",
-          "items": [
-            {
-              "text": "资源转存",
-              "link": "/cookbook/practice/assets.md"
-            },
-            {
-              "text": "图片渲染",
-              "link": "/cookbook/practice/render.md"
-            },
-            {
-              "text": "部署到 k-on!",
-              "link": "/cookbook/practice/online.md"
-            },
-            {
-              "text": "整合包开发",
-              "link": "/cookbook/practice/bundle.md"
-            },
-            {
-              "text": "编写测试",
-              "link": "/cookbook/practice/testing.md"
-            }
-          ]
-        },
-        {
-          "text": "案例分析",
-          "items": [
-            {
-              "text": "指令管理",
-              "link": "/cookbook/appendix/commands.md"
-            }
-          ]
-        }
-      ],
-      "/plugins/": [
-        {
-          "text": "插件",
-          "items": [
-            {
-              "text": "插件市场",
-              "link": "/market/"
-            },
-            {
-              "text": "官方插件一览",
-              "link": "/plugins/"
-            }
-          ]
-        },
-        {
-          "text": "适配器支持",
-          "items": [
-            {
-              "text": "钉钉",
-              "link": "/plugins/adapter/dingtalk.md"
-            },
-            {
-              "text": "Discord",
-              "link": "/plugins/adapter/discord.md"
-            },
-            {
-              "text": "Kook",
-              "link": "/plugins/adapter/kook.md"
-            },
-            {
-              "text": "飞书",
-              "link": "/plugins/adapter/lark.md"
-            },
-            {
-              "text": "LINE",
-              "link": "/plugins/adapter/line.md"
-            },
-            {
-              "text": "邮件",
-              "link": "/plugins/adapter/mail.md"
-            },
-            {
-              "text": "Matrix",
-              "link": "/plugins/adapter/matrix.md"
-            },
-            {
-              "text": "QQ",
-              "link": "/plugins/adapter/qq.md"
-            },
-            {
-              "text": "Satori",
-              "link": "/plugins/adapter/satori.md"
-            },
-            {
-              "text": "Slack",
-              "link": "/plugins/adapter/slack.md"
-            },
-            {
-              "text": "Telegram",
-              "link": "/plugins/adapter/telegram.md"
-            },
-            {
-              "text": "微信公众号",
-              "link": "/plugins/adapter/wechat-official.md"
-            },
-            {
-              "text": "企业微信",
-              "link": "/plugins/adapter/wecom.md"
-            },
-            {
-              "text": "WhatsApp",
-              "link": "/plugins/adapter/whatsapp.md"
-            },
-            {
-              "text": "Zulip",
-              "link": "/plugins/adapter/zulip.md"
-            }
-          ]
-        },
-        {
-          "text": "数据库支持",
-          "items": [
-            {
-              "text": "Memory",
-              "link": "/plugins/database/memory.md"
-            },
-            {
-              "text": "MongoDB",
-              "link": "/plugins/database/mongo.md"
-            },
-            {
-              "text": "MySQL / MariaDB",
-              "link": "/plugins/database/mysql.md"
-            },
-            {
-              "text": "PostgreSQL",
-              "link": "/plugins/database/postgres.md"
-            },
-            {
-              "text": "SQLite",
-              "link": "/plugins/database/sqlite.md"
-            }
-          ]
-        },
-        {
-          "text": "常用功能",
-          "items": [
-            {
-              "text": "数据管理 (Admin)",
-              "link": "/plugins/common/admin.md"
-            },
-            {
-              "text": "账号绑定 (Bind)",
-              "link": "/plugins/common/bind.md"
-            },
-            {
-              "text": "发送广播 (Broadcast)",
-              "link": "/plugins/common/broadcast.md"
-            },
-            {
-              "text": "设置昵称 (Callme)",
-              "link": "/plugins/common/callme.md"
-            },
-            {
-              "text": "发送消息 (Echo)",
-              "link": "/plugins/common/echo.md"
-            },
-            {
-              "text": "查看帮助 (Help)",
-              "link": "/plugins/common/help.md"
-            },
-            {
-              "text": "会话信息 (Inspect)",
-              "link": "/plugins/common/inspect.md"
-            }
-          ]
-        },
-        {
-          "text": "控制台功能",
-          "items": [
-            {
-              "text": "数据统计 (Analytics)",
-              "link": "/plugins/console/analytics.md"
-            },
-            {
-              "text": "用户登录 (Auth)",
-              "link": "/plugins/console/auth.md"
-            },
-            {
-              "text": "指令管理 (Commands)",
-              "link": "/plugins/console/commands.md"
-            },
-            {
-              "text": "插件配置 (Config)",
-              "link": "/plugins/console/config.md"
-            },
-            {
-              "text": "控制台 (Console)",
-              "link": "/plugins/console/index.md"
-            },
-            {
-              "text": "资源管理器 (Explorer)",
-              "link": "/plugins/console/explorer.md"
-            },
-            {
-              "text": "插件依赖图 (Insight)",
-              "link": "/plugins/console/insight.md"
-            },
-            {
-              "text": "本地翻译 (Locales)",
-              "link": "/plugins/console/locales.md"
-            },
-            {
-              "text": "日志管理 (Logger)",
-              "link": "/plugins/console/logger.md"
-            },
-            {
-              "text": "插件市场 (Market)",
-              "link": "/plugins/console/market.md"
-            },
-            {
-              "text": "沙箱调试 (Sandbox)",
-              "link": "/plugins/console/sandbox.md"
-            },
-            {
-              "text": "运行状态 (Status)",
-              "link": "/plugins/console/status.md"
-            }
-          ]
-        },
-        {
-          "text": "开发工具",
-          "items": [
-            {
-              "text": "模块热替换 (HMR)",
-              "link": "/plugins/develop/hmr.md"
-            },
-            {
-              "text": "网络请求 (HTTP)",
-              "link": "/plugins/develop/http.md"
-            },
-            {
-              "text": "测试工具 (Mock)",
-              "link": "/plugins/develop/mock.md"
-            },
-            {
-              "text": "通知服务 (Notifier)",
-              "link": "/plugins/develop/notifier.md"
-            },
-            {
-              "text": "网络代理 (Proxy Agent)",
-              "link": "/plugins/develop/proxy-agent.md"
-            },
-            {
-              "text": "服务器 (Server)",
-              "link": "/plugins/develop/server.md"
-            },
-            {
-              "text": "API 服务器 (Server Satori)",
-              "link": "/plugins/develop/server-satori.md"
-            },
-            {
-              "text": "临时服务器 (Server Temp)",
-              "link": "/plugins/develop/server-temp.md"
-            }
-          ]
-        }
-      ],
-      "/market/": [
-        {
-          "text": "插件",
-          "items": [
-            {
-              "text": "插件市场",
-              "link": "/market/"
-            },
-            {
-              "text": "官方插件一览",
-              "link": "/plugins/"
-            }
-          ]
-        }
-      ],
-      "/schema/": [
-        {
-          "text": "演练场",
-          "items": [
-            {
-              "text": "配置构型",
-              "link": "/schema/index.md"
-            }
-          ]
-        },
-        {
-          "text": "核心概念",
-          "items": [
-            {
-              "text": "必需与可选",
-              "link": "/schema/meta/required.md"
-            },
-            {
-              "text": "默认值",
-              "link": "/schema/meta/default.md"
-            },
-            {
-              "text": "标题与描述",
-              "link": "/schema/meta/description.md"
-            },
-            {
-              "text": "禁用与隐藏",
-              "link": "/schema/meta/disabled.md"
-            },
-            {
-              "text": "配置项外观",
-              "link": "/schema/meta/role.md"
-            },
-            {
-              "text": "嵌套类型",
-              "link": "/schema/meta/nested.md"
-            }
-          ]
-        },
-        {
-          "text": "基础类型",
-          "items": [
-            {
-              "text": "数值 (Number)",
-              "link": "/schema/basic/number.md"
-            },
-            {
-              "text": "字符串 (String)",
-              "link": "/schema/basic/string.md"
-            },
-            {
-              "text": "布尔值 (Boolean)",
-              "link": "/schema/basic/boolean.md"
-            },
-            {
-              "text": "日期 (Date)",
-              "link": "/schema/basic/date.md"
-            },
-            {
-              "text": "位集 (Bitset)",
-              "link": "/schema/basic/bitset.md"
-            },
-            {
-              "text": "对象 (Object)",
-              "link": "/schema/basic/object.md"
-            },
-            {
-              "text": "元组 (Tuple)",
-              "link": "/schema/basic/tuple.md"
-            },
-            {
-              "text": "字典 (Dict)",
-              "link": "/schema/basic/dict.md"
-            },
-            {
-              "text": "数组 (Array)",
-              "link": "/schema/basic/array.md"
-            },
-            {
-              "text": "路径 (Path)",
-              "link": "/schema/basic/path.md"
-            }
-          ]
-        },
-        {
-          "text": "高级类型",
-          "items": [
-            {
-              "text": "Intersect：分组",
-              "link": "/schema/advanced/intersect.md"
-            },
-            {
-              "text": "Union：单选框",
-              "link": "/schema/advanced/union-select.md"
-            },
-            {
-              "text": "Union：联合类型",
-              "link": "/schema/advanced/union-arbitrary.md"
-            },
-            {
-              "text": "Intersect + Union：配置联动 1",
-              "link": "/schema/advanced/union-tagged-1.md"
-            },
-            {
-              "text": "Intersect + Union：配置联动 2",
-              "link": "/schema/advanced/union-tagged-2.md"
-            },
-            {
-              "text": "Transform：输入转换",
-              "link": "/schema/advanced/transform.md"
-            },
-            {
-              "text": "Computed：条件求值",
-              "link": "/schema/advanced/computed.md"
-            }
-          ]
-        }
-      ],
-      "/about/": [
-        {
-          "text": "关于",
-          "items": [
-            {
-              "text": "许可证",
-              "link": "/about/license.md"
-            },
-            {
-              "text": "参与讨论",
-              "link": "/about/contact.md"
-            },
-            {
-              "text": "认识团队",
-              "link": "/about/team.md"
-            },
-            {
-              "text": "常见问题",
-              "link": "/about/faq.md"
-            },
-            {
-              "text": "社区资源",
-              "link": "/about/community.md"
-            },
-            {
-              "text": "大事件",
-              "link": "/about/events.md"
-            }
-          ]
-        },
-        {
-          "text": "更新",
-          "items": [
-            {
-              "text": "发展史",
-              "link": "/about/history.md"
-            },
-            {
-              "text": "更新计划",
-              "link": "/about/releases.md"
-            },
-            {
-              "text": "从低版本迁移",
-              "link": "/about/upgrade.md"
-            },
-            {
-              "text": "各版本介绍",
-              "link": "/releases/index.md"
-            },
-            {
-              "text": "更新日志",
-              "link": "https://github.com/koishijs/koishi/releases"
-            }
-          ]
-        },
-        {
-          "text": "贡献",
-          "items": [
-            {
-              "text": "项目结构",
-              "link": "/about/contribute/structure.md"
-            },
-            {
-              "text": "文档贡献指南",
-              "link": "/about/contribute/docs.md"
-            }
-          ]
-        }
-      ],
-      "/releases": [
-        {
-          "text": "",
-          "items": [
-            {
-              "text": "各版本介绍",
-              "link": "/releases/index.md"
-            },
-            {
-              "text": "v4.1 版本介绍",
-              "link": "/releases/v4.1.md"
-            },
-            {
-              "text": "v4.2 版本介绍",
-              "link": "/releases/v4.2.md"
-            },
-            {
-              "text": "v4.3 版本介绍",
-              "link": "/releases/v4.3.md"
-            },
-            {
-              "text": "v4.4 版本介绍",
-              "link": "/releases/v4.4.md"
-            },
-            {
-              "text": "v4.5 版本介绍",
-              "link": "/releases/v4.5.md"
-            },
-            {
-              "text": "v4.6 版本介绍",
-              "link": "/releases/v4.6.md"
-            },
-            {
-              "text": "v4.7 版本介绍",
-              "link": "/releases/v4.7.md"
-            },
-            {
-              "text": "v4.8 版本介绍",
-              "link": "/releases/v4.8.md"
-            },
-            {
-              "text": "v4.9 版本介绍",
-              "link": "/releases/v4.9.md"
-            },
-            {
-              "text": "v4.10 版本介绍",
-              "link": "/releases/v4.10.md"
-            },
-            {
-              "text": "v4.11 版本介绍",
-              "link": "/releases/v4.11.md"
-            },
-            {
-              "text": "v4.12 版本介绍",
-              "link": "/releases/v4.12.md"
-            },
-            {
-              "text": "v4.13 版本介绍",
-              "link": "/releases/v4.13.md"
-            },
-            {
-              "text": "v4.14 版本介绍",
-              "link": "/releases/v4.14.md"
-            },
-            {
-              "text": "v4.15 版本介绍",
-              "link": "/releases/v4.15.md"
-            }
-          ]
-        },
-        {
-          "text": "",
-          "items": [
-            {
-              "text": "更新日志",
-              "link": "https://github.com/koishijs/koishi/releases"
-            }
-          ]
-        }
-      ]
+          "link": "/guide/basic/element.md"
+        }, {
+          "text": "进阶用法",
+          "link": "/guide/basic/advanced.md"
+        }]
+      }, {
+        "text": "模块化",
+        "items": [{
+          "text": "认识插件",
+          "link": "/guide/plugin/"
+        }, {
+          "text": "配置构型",
+          "link": "/guide/plugin/schema.md"
+        }, {
+          "text": "生命周期",
+          "link": "/guide/plugin/lifecycle.md"
+        }, {
+          "text": "服务与依赖",
+          "link": "/guide/plugin/service.md"
+        }, {
+          "text": "过滤器",
+          "link": "/guide/plugin/filter.md"
+        }]
+      }, {
+        "text": "数据库",
+        "items": [{
+          "text": "基本用法",
+          "link": "/guide/database/"
+        }, {
+          "text": "数据模型",
+          "link": "/guide/database/model.md"
+        }, {
+          "text": "进阶查询技巧",
+          "link": "/guide/database/selection.md"
+        }, {
+          "text": "内置数据结构",
+          "link": "/guide/database/builtin.md"
+        }, {
+          "text": "权限管理",
+          "link": "/guide/database/permission.md"
+        }]
+      }, {
+        "text": "跨平台",
+        "items": [{
+          "text": "基础知识",
+          "link": "/guide/adapter/index.md"
+        }, {
+          "text": "实现机器人",
+          "link": "/guide/adapter/bot.md"
+        }, {
+          "text": "实现适配器",
+          "link": "/guide/adapter/adapter.md"
+        }, {
+          "text": "消息编码",
+          "link": "/guide/adapter/message.md"
+        }, {
+          "text": "平台集成",
+          "link": "/guide/adapter/integration.md"
+        }]
+      }, {
+        "text": "控制台",
+        "items": [{
+          "text": "扩展控制台",
+          "link": "/guide/console/index.md"
+        }, {
+          "text": "数据交互",
+          "link": "/guide/console/data.md"
+        }, {
+          "text": "客户端开发",
+          "link": "/guide/console/client.md"
+        }, {
+          "text": "主题开发",
+          "link": "/guide/console/theme.md"
+        }]
+      }, {
+        "text": "国际化",
+        "items": [{
+          "text": "基本用法",
+          "link": "/guide/i18n/index.md"
+        }, {
+          "text": "本地化文件",
+          "link": "/guide/i18n/translation.md"
+        }, {
+          "text": "语言包开发",
+          "link": "/guide/i18n/lang-pack.md"
+        }, {
+          "text": "接入 Crowdin",
+          "link": "/guide/i18n/crowdin.md"
+        }]
+      }, {
+        "items": [{
+          "text": "→ 进阶指南",
+          "link": "/cookbook/"
+        }]
+      }],
+      "/api/": [{
+        "text": "",
+        "items": [{
+          "text": "总览",
+          "link": "/api/"
+        }, {
+          "text": "术语表",
+          "link": "/api/glossary.md"
+        }]
+      }, {
+        "text": "演练场",
+        "desc": "我们专门为一些 API 提供了交互式的演练场。",
+        "items": [{
+          "text": "配置构型",
+          "link": "/schema/"
+        }]
+      }, {
+        "text": "核心模块",
+        "items": [{
+          "text": "适配器 (Adapter)",
+          "link": "/api/core/adapter.md"
+        }, {
+          "text": "应用 (App)",
+          "link": "/api/core/app.md"
+        }, {
+          "text": "机器人 (Bot)",
+          "link": "/api/core/bot.md"
+        }, {
+          "text": "指令 (Command)",
+          "link": "/api/core/command.md"
+        }, {
+          "text": "上下文 (Context)",
+          "link": "/api/core/context.md"
+        }, {
+          "text": "事件 (Events)",
+          "link": "/api/core/events.md"
+        }, {
+          "text": "会话 (Session)",
+          "link": "/api/core/session.md"
+        }]
+      }, {
+        "text": "内置服务",
+        "items": [{
+          "text": "事件系统 (Events)",
+          "link": "/api/service/events.md"
+        }, {
+          "text": "过滤器 (Filter)",
+          "link": "/api/service/filter.md"
+        }, {
+          "text": "网络请求 (HTTP)",
+          "link": "/api/service/http.md"
+        }, {
+          "text": "国际化 (I18n)",
+          "link": "/api/service/i18n.md"
+        }, {
+          "text": "加载器 (Loader)",
+          "link": "/api/service/loader.md"
+        }, {
+          "text": "权限管理 (Permissions)",
+          "link": "/api/service/permissions.md"
+        }, {
+          "text": "插件系统 (Registry)",
+          "link": "/api/service/registry.md"
+        }, {
+          "text": "服务器 (Server)",
+          "link": "/api/service/server.md"
+        }, {
+          "text": "计时器 (Timer)",
+          "link": "/api/service/timer.md"
+        }]
+      }, {
+        "text": "平台资源",
+        "items": [{
+          "text": "频道 (Channel)",
+          "link": "/api/resources/channel.md"
+        }, {
+          "text": "群组 (Guild)",
+          "link": "/api/resources/guild.md"
+        }, {
+          "text": "群组成员 (GuildMember)",
+          "link": "/api/resources/member.md"
+        }, {
+          "text": "群组角色 (GuildRole)",
+          "link": "/api/resources/role.md"
+        }, {
+          "text": "交互 (Interaction)",
+          "link": "/api/resources/interaction.md"
+        }, {
+          "text": "登录状态 (Login)",
+          "link": "/api/resources/login.md"
+        }, {
+          "text": "消息 (Message)",
+          "link": "/api/resources/message.md"
+        }, {
+          "text": "表态 (Reaction)",
+          "link": "/api/resources/reaction.md"
+        }, {
+          "text": "用户 (User)",
+          "link": "/api/resources/user.md"
+        }]
+      }, {
+        "text": "消息元素",
+        "items": [{
+          "text": "语法规范",
+          "link": "/api/message/syntax.md"
+        }, {
+          "text": "标准元素",
+          "link": "/api/message/elements.md"
+        }, {
+          "text": "内置组件",
+          "link": "/api/message/components.md"
+        }, {
+          "text": "渲染函数",
+          "link": "/api/message/api.md"
+        }, {
+          "text": "消息编码器",
+          "link": "/api/message/encoder.md"
+        }]
+      }, {
+        "text": "数据库",
+        "items": [{
+          "text": "数据模型 (Model)",
+          "link": "/api/database/model.md"
+        }, {
+          "text": "数据库操作 (Database)",
+          "link": "/api/database/database.md"
+        }, {
+          "text": "查询表达式 (Query)",
+          "link": "/api/database/query.md"
+        }, {
+          "text": "求值表达式 (Eval)",
+          "link": "/api/database/evaluation.md"
+        }, {
+          "text": "查询构造器 (Selection)",
+          "link": "/api/database/selection.md"
+        }, {
+          "text": "内置数据结构",
+          "link": "/api/database/built-in.md"
+        }]
+      }, {
+        "text": "控制台",
+        "items": [{
+          "text": "服务端 API",
+          "link": "/api/console/server.md"
+        }, {
+          "text": "上下文 API",
+          "link": "/api/console/context.md"
+        }, {
+          "text": "组合式 API",
+          "link": "/api/console/composition.md"
+        }, {
+          "text": "内置组件",
+          "link": "/api/console/component.md"
+        }]
+      }, {
+        "text": "其他功能",
+        "items": [{
+          "text": "观察者 (Observer)",
+          "link": "/api/utils/observer.md"
+        }, {
+          "text": "输出日志 (Logger)",
+          "link": "/api/utils/logger.md"
+        }, {
+          "text": "随机操作 (Random)",
+          "link": "/api/utils/random.md"
+        }, {
+          "text": "其他工具 (Misc)",
+          "link": "/api/utils/misc.md"
+        }]
+      }],
+      "/cookbook/": [{
+        "items": [{
+          "text": "总览",
+          "link": "/cookbook/"
+        }]
+      }, {
+        "text": "设计原理",
+        "items": [{
+          "text": "项目架构",
+          "link": "/cookbook/design/structure.md"
+        }, {
+          "text": "可逆的插件系统",
+          "link": "/cookbook/design/disposable.md"
+        }, {
+          "text": "从元框架到框架",
+          "link": "/cookbook/design/framework.md"
+        }, {
+          "text": "零占用的存储",
+          "link": "/cookbook/design/storage.md"
+        }, {
+          "text": "深入工作区",
+          "link": "/cookbook/design/workspace.md"
+        }]
+      }, {
+        "text": "最佳实践",
+        "items": [{
+          "text": "资源转存",
+          "link": "/cookbook/practice/assets.md"
+        }, {
+          "text": "图片渲染",
+          "link": "/cookbook/practice/render.md"
+        }, {
+          "text": "部署到 k-on!",
+          "link": "/cookbook/practice/online.md"
+        }, {
+          "text": "整合包开发",
+          "link": "/cookbook/practice/bundle.md"
+        }, {
+          "text": "编写测试",
+          "link": "/cookbook/practice/testing.md"
+        }]
+      }, {
+        "text": "案例分析",
+        "items": [{
+          "text": "指令管理",
+          "link": "/cookbook/appendix/commands.md"
+        }]
+      }],
+      "/plugins/": [{
+        "text": "插件",
+        "items": [{
+          "text": "插件市场",
+          "link": "/market/"
+        }, {
+          "text": "官方插件一览",
+          "link": "/plugins/"
+        }]
+      }, {
+        "text": "适配器支持",
+        "items": [{
+          "text": "钉钉",
+          "link": "/plugins/adapter/dingtalk.md"
+        }, {
+          "text": "Discord",
+          "link": "/plugins/adapter/discord.md"
+        }, {
+          "text": "Kook",
+          "link": "/plugins/adapter/kook.md"
+        }, {
+          "text": "飞书",
+          "link": "/plugins/adapter/lark.md"
+        }, {
+          "text": "LINE",
+          "link": "/plugins/adapter/line.md"
+        }, {
+          "text": "邮件",
+          "link": "/plugins/adapter/mail.md"
+        }, {
+          "text": "Matrix",
+          "link": "/plugins/adapter/matrix.md"
+        }, {
+          "text": "QQ",
+          "link": "/plugins/adapter/qq.md"
+        }, {
+          "text": "Satori",
+          "link": "/plugins/adapter/satori.md"
+        }, {
+          "text": "Slack",
+          "link": "/plugins/adapter/slack.md"
+        }, {
+          "text": "Telegram",
+          "link": "/plugins/adapter/telegram.md"
+        }, {
+          "text": "微信公众号",
+          "link": "/plugins/adapter/wechat-official.md"
+        }, {
+          "text": "企业微信",
+          "link": "/plugins/adapter/wecom.md"
+        }, {
+          "text": "WhatsApp",
+          "link": "/plugins/adapter/whatsapp.md"
+        }, {
+          "text": "Zulip",
+          "link": "/plugins/adapter/zulip.md"
+        }]
+      }, {
+        "text": "数据库支持",
+        "items": [{
+          "text": "Memory",
+          "link": "/plugins/database/memory.md"
+        }, {
+          "text": "MongoDB",
+          "link": "/plugins/database/mongo.md"
+        }, {
+          "text": "MySQL / MariaDB",
+          "link": "/plugins/database/mysql.md"
+        }, {
+          "text": "PostgreSQL",
+          "link": "/plugins/database/postgres.md"
+        }, {
+          "text": "SQLite",
+          "link": "/plugins/database/sqlite.md"
+        }]
+      }, {
+        "text": "常用功能",
+        "items": [{
+          "text": "数据管理 (Admin)",
+          "link": "/plugins/common/admin.md"
+        }, {
+          "text": "账号绑定 (Bind)",
+          "link": "/plugins/common/bind.md"
+        }, {
+          "text": "发送广播 (Broadcast)",
+          "link": "/plugins/common/broadcast.md"
+        }, {
+          "text": "设置昵称 (Callme)",
+          "link": "/plugins/common/callme.md"
+        }, {
+          "text": "发送消息 (Echo)",
+          "link": "/plugins/common/echo.md"
+        }, {
+          "text": "查看帮助 (Help)",
+          "link": "/plugins/common/help.md"
+        }, {
+          "text": "会话信息 (Inspect)",
+          "link": "/plugins/common/inspect.md"
+        }]
+      }, {
+        "text": "控制台功能",
+        "items": [{
+          "text": "数据统计 (Analytics)",
+          "link": "/plugins/console/analytics.md"
+        }, {
+          "text": "用户登录 (Auth)",
+          "link": "/plugins/console/auth.md"
+        }, {
+          "text": "指令管理 (Commands)",
+          "link": "/plugins/console/commands.md"
+        }, {
+          "text": "插件配置 (Config)",
+          "link": "/plugins/console/config.md"
+        }, {
+          "text": "控制台 (Console)",
+          "link": "/plugins/console/index.md"
+        }, {
+          "text": "资源管理器 (Explorer)",
+          "link": "/plugins/console/explorer.md"
+        }, {
+          "text": "插件依赖图 (Insight)",
+          "link": "/plugins/console/insight.md"
+        }, {
+          "text": "本地翻译 (Locales)",
+          "link": "/plugins/console/locales.md"
+        }, {
+          "text": "日志管理 (Logger)",
+          "link": "/plugins/console/logger.md"
+        }, {
+          "text": "插件市场 (Market)",
+          "link": "/plugins/console/market.md"
+        }, {
+          "text": "沙箱调试 (Sandbox)",
+          "link": "/plugins/console/sandbox.md"
+        }, {
+          "text": "运行状态 (Status)",
+          "link": "/plugins/console/status.md"
+        }]
+      }, {
+        "text": "开发工具",
+        "items": [{
+          "text": "模块热替换 (HMR)",
+          "link": "/plugins/develop/hmr.md"
+        }, {
+          "text": "网络请求 (HTTP)",
+          "link": "/plugins/develop/http.md"
+        }, {
+          "text": "测试工具 (Mock)",
+          "link": "/plugins/develop/mock.md"
+        }, {
+          "text": "通知服务 (Notifier)",
+          "link": "/plugins/develop/notifier.md"
+        }, {
+          "text": "网络代理 (Proxy Agent)",
+          "link": "/plugins/develop/proxy-agent.md"
+        }, {
+          "text": "服务器 (Server)",
+          "link": "/plugins/develop/server.md"
+        }, {
+          "text": "API 服务器 (Server Satori)",
+          "link": "/plugins/develop/server-satori.md"
+        }, {
+          "text": "临时服务器 (Server Temp)",
+          "link": "/plugins/develop/server-temp.md"
+        }]
+      }],
+      "/market/": [{
+        "text": "插件",
+        "items": [{
+          "text": "插件市场",
+          "link": "/market/"
+        }, {
+          "text": "官方插件一览",
+          "link": "/plugins/"
+        }]
+      }],
+      "/schema/": [{
+        "text": "演练场",
+        "items": [{
+          "text": "配置构型",
+          "link": "/schema/index.md"
+          }]
+      }, {
+        "text": "核心概念",
+        "items": [{
+          "text": "必需与可选",
+          "link": "/schema/meta/required.md"
+        }, {
+          "text": "默认值",
+          "link": "/schema/meta/default.md"
+        }, {
+          "text": "标题与描述",
+          "link": "/schema/meta/description.md"
+        }, {
+          "text": "禁用与隐藏",
+          "link": "/schema/meta/disabled.md"
+        }, {
+          "text": "配置项外观",
+          "link": "/schema/meta/role.md"
+        }, {
+          "text": "嵌套类型",
+          "link": "/schema/meta/nested.md"
+        }]
+      }, {
+        "text": "基础类型",
+        "items": [{
+          "text": "数值 (Number)",
+          "link": "/schema/basic/number.md"
+        }, {
+          "text": "字符串 (String)",
+          "link": "/schema/basic/string.md"
+        }, {
+          "text": "布尔值 (Boolean)",
+          "link": "/schema/basic/boolean.md"
+        }, {
+          "text": "日期 (Date)",
+          "link": "/schema/basic/date.md"
+        }, {
+          "text": "位集 (Bitset)",
+          "link": "/schema/basic/bitset.md"
+        }, {
+          "text": "对象 (Object)",
+          "link": "/schema/basic/object.md"
+        }, {
+          "text": "元组 (Tuple)",
+          "link": "/schema/basic/tuple.md"
+        }, {
+          "text": "字典 (Dict)",
+          "link": "/schema/basic/dict.md"
+        }, {
+          "text": "数组 (Array)",
+          "link": "/schema/basic/array.md"
+        }, {
+          "text": "路径 (Path)",
+          "link": "/schema/basic/path.md"
+        }]
+      }, {
+        "text": "高级类型",
+        "items": [{
+          "text": "Intersect：分组",
+          "link": "/schema/advanced/intersect.md"
+        }, {
+          "text": "Union：单选框",
+          "link": "/schema/advanced/union-select.md"
+        }, {
+          "text": "Union：联合类型",
+          "link": "/schema/advanced/union-arbitrary.md"
+        }, {
+          "text": "Intersect + Union：配置联动 1",
+          "link": "/schema/advanced/union-tagged-1.md"
+        }, {
+          "text": "Intersect + Union：配置联动 2",
+          "link": "/schema/advanced/union-tagged-2.md"
+        }, {
+          "text": "Transform：输入转换",
+          "link": "/schema/advanced/transform.md"
+        }, {
+          "text": "Computed：条件求值",
+          "link": "/schema/advanced/computed.md"
+        }]
+      }],
+      "/about/": [{
+        "text": "关于",
+        "items": [{
+          "text": "许可证",
+          "link": "/about/license.md"
+        }, {
+          "text": "参与讨论",
+          "link": "/about/contact.md"
+        }, {
+          "text": "认识团队",
+          "link": "/about/team.md"
+        }, {
+          "text": "常见问题",
+          "link": "/about/faq.md"
+        }, {
+          "text": "社区资源",
+          "link": "/about/community.md"
+        }, {
+          "text": "大事件",
+          "link": "/about/events.md"
+        }]
+      }, {
+        "text": "更新",
+        "items": [{
+          "text": "发展史",
+          "link": "/about/history.md"
+        }, {
+          "text": "更新计划",
+          "link": "/about/releases.md"
+        }, {
+          "text": "从低版本迁移",
+          "link": "/about/upgrade.md"
+        }, {
+          "text": "各版本介绍",
+          "link": "/releases/index.md"
+        }, {
+          "text": "更新日志",
+          "link": "https://github.com/koishijs/koishi/releases"
+        }]
+      }, {
+        "text": "贡献",
+        "items": [{
+          "text": "项目结构",
+          "link": "/about/contribute/structure.md"
+        }, {
+          "text": "文档贡献指南",
+          "link": "/about/contribute/docs.md"
+        }]
+      }],
+      "/releases": [{
+        "text": "",
+        "items": [{
+          "text": "各版本介绍",
+          "link": "/releases/index.md"
+        }, {
+          "text": "v4.1 版本介绍",
+          "link": "/releases/v4.1.md"
+        }, {
+          "text": "v4.2 版本介绍",
+          "link": "/releases/v4.2.md"
+        }, {
+          "text": "v4.3 版本介绍",
+          "link": "/releases/v4.3.md"
+        }, {
+          "text": "v4.4 版本介绍",
+          "link": "/releases/v4.4.md"
+        }, {
+          "text": "v4.5 版本介绍",
+          "link": "/releases/v4.5.md"
+        }, {
+          "text": "v4.6 版本介绍",
+          "link": "/releases/v4.6.md"
+        }, {
+          "text": "v4.7 版本介绍",
+          "link": "/releases/v4.7.md"
+        }, {
+          "text": "v4.8 版本介绍",
+          "link": "/releases/v4.8.md"
+        }, {
+          "text": "v4.9 版本介绍",
+          "link": "/releases/v4.9.md"
+        }, {
+          "text": "v4.10 版本介绍",
+          "link": "/releases/v4.10.md"
+        }, {
+          "text": "v4.11 版本介绍",
+          "link": "/releases/v4.11.md"
+        }, {
+          "text": "v4.12 版本介绍",
+          "link": "/releases/v4.12.md"
+        }, {
+          "text": "v4.13 版本介绍",
+          "link": "/releases/v4.13.md"
+        }, {
+          "text": "v4.14 版本介绍",
+          "link": "/releases/v4.14.md"
+        }, {
+          "text": "v4.15 版本介绍",
+          "link": "/releases/v4.15.md"
+        }]
+      }, {
+        "text": "",
+        "items": [{
+          "text": "更新日志",
+          "link": "https://github.com/koishijs/koishi/releases"
+        }]
+      }]
     }
   }
 }

--- a/.vitepress/config/zh-CN.json
+++ b/.vitepress/config/zh-CN.json
@@ -1,9 +1,27 @@
 {
   "description": "创建跨平台、可扩展、高性能的机器人",
   "head": [
-    ["link", { "rel": "icon", "href": "/logo.png" }],
-    ["link", { "rel": "manifest", "href": "/manifest/zh-CN.json" }],
-    ["meta", { "name": "theme-color", "content": "#5546a3" }]
+    [
+      "link",
+      {
+        "rel": "icon",
+        "href": "/logo.png"
+      }
+    ],
+    [
+      "link",
+      {
+        "rel": "manifest",
+        "href": "/manifest/zh-CN.json"
+      }
+    ],
+    [
+      "meta",
+      {
+        "name": "theme-color",
+        "content": "#5546a3"
+      }
+    ]
   ],
   "themeConfig": {
     "editLink": {
@@ -11,845 +29,1176 @@
       "pattern": "https://github.com/koishijs/docs/edit/main/:path"
     },
     "navText": "导航",
-    "nav": [{
-      "text": "入门",
-      "link": "/manual/introduction.md",
-      "activeMatch": "/manual/"
-    }, {
-      "text": "开发",
-      "items": [{
-        "text": "开发指南",
-        "link": "/guide/"
-      }, {
-        "text": "进阶指南",
-        "link": "/cookbook/"
-      }, {
-        "text": "API 参考",
-        "link": "/api/"
-      }, {
-        "text": "演练场：配置构型",
-        "link": "/schema/"
-      }],
-      "activeMatch": "/(guide|api|schema|cookbook)/"
-    }, {
-      "text": "插件",
-      "items": [{
-        "text": "插件市场",
-        "link": "/market/"
-      }, {
-        "text": "官方插件一览",
-        "link": "/plugins/"
-      }],
-      "activeMatch": "/(plugins|market)/"
-    }, {
-      "text": "更多",
-      "items": [{
-        "text": "参与讨论",
-        "link": "/about/contact.md"
-      }, {
-        "text": "社区资源",
-        "link": "/about/community.md"
-      }, {
-        "text": "各版本介绍",
-        "link": "/releases/index.md"
-      }],
-      "activeMatch": "/(about|releases)/"
-    }],
+    "nav": [
+      {
+        "text": "入门",
+        "link": "/manual/introduction.md",
+        "activeMatch": "/manual/"
+      },
+      {
+        "text": "开发",
+        "items": [
+          {
+            "text": "开发指南",
+            "link": "/guide/"
+          },
+          {
+            "text": "进阶指南",
+            "link": "/cookbook/"
+          },
+          {
+            "text": "API 参考",
+            "link": "/api/"
+          },
+          {
+            "text": "演练场：配置构型",
+            "link": "/schema/"
+          }
+        ],
+        "activeMatch": "/(guide|api|schema|cookbook)/"
+      },
+      {
+        "text": "插件",
+        "items": [
+          {
+            "text": "插件市场",
+            "link": "/market/"
+          },
+          {
+            "text": "官方插件一览",
+            "link": "/plugins/"
+          }
+        ],
+        "activeMatch": "/(plugins|market)/"
+      },
+      {
+        "text": "更多",
+        "items": [
+          {
+            "text": "参与讨论",
+            "link": "/about/contact.md"
+          },
+          {
+            "text": "社区资源",
+            "link": "/about/community.md"
+          },
+          {
+            "text": "各版本介绍",
+            "link": "/releases/index.md"
+          }
+        ],
+        "activeMatch": "/(about|releases)/"
+      }
+    ],
     "sidebar": {
-      "/manual/": [{
-        "text": "",
-        "items": [{
-          "text": "介绍",
-          "link": "/manual/introduction.md"
-        }]
-      }, {
-        "text": "",
-        "items": [{
-          "text": "安装",
-          "link": "/manual/starter/"
-        }, {
-          "text": "为 Windows 安装",
-          "link": "/manual/starter/windows.md"
-        }, {
-          "text": "为 macOS 安装",
-          "link": "/manual/starter/macos.md"
-        }, {
-          "text": "为 Linux 安装",
-          "link": "/manual/starter/linux.md"
-        }, {
-          "text": "为 Android 安装",
-          "link": "/manual/starter/android.md"
-        }, {
-          "text": "在容器中使用",
-          "link": "/manual/starter/docker.md"
-        }, {
-          "text": "创建模板项目",
-          "link": "/manual/starter/boilerplate.md"
-        }, {
-          "text": "作为依赖调用",
-          "link": "/manual/starter/direct.md"
-        }]
-      }, {
-        "text": "使用",
-        "items": [{
-          "text": "安装和配置插件",
-          "link": "/manual/usage/market.md"
-        }, {
-          "text": "第一次对话",
-          "link": "/manual/usage/adapter.md"
-        }, {
-          "text": "指令系统",
-          "link": "/manual/usage/command.md"
-        }, {
-          "text": "账号登录与绑定",
-          "link": "/manual/usage/platform.md"
-        }, {
-          "text": "深入定制机器人",
-          "link": "/manual/usage/customize.md"
-        }]
-      }, {
-        "text": "配方",
-        "items": [{
-          "text": "指令进阶技巧",
-          "link": "/manual/recipe/execution.md"
-        }, {
-          "text": "维护多份配置",
-          "link": "/manual/recipe/multiple.md"
-        }, {
-          "text": "搜索插件市场",
-          "link": "/manual/recipe/search.md"
-        }, {
-          "text": "公网部署",
-          "link": "/manual/recipe/server.md"
-        }]
-      }, {
-        "text": "启动器",
-        "items": [{
-          "text": "系统要求",
-          "link": "/manual/launcher/system.md"
-        }, {
-          "text": "命令行工具",
-          "link": "/manual/launcher/cli.md"
-        }]
-      }],
-      "/guide/": [{
-        "text": "",
-        "items": [{
-          "text": "总览",
-          "link": "/guide/"
-        }]
-      }, {
-        "text": "开发起步",
-        "items": [{
-          "text": "环境搭建",
-          "link": "/guide/develop/setup.md"
-        }, {
-          "text": "配置文件",
-          "link": "/guide/develop/config.md"
-        }, {
-          "text": "启动脚本",
-          "link": "/guide/develop/script.md"
-        }, {
-          "text": "工作区开发",
-          "link": "/guide/develop/workspace.md"
-        }, {
-          "text": "发布插件",
-          "link": "/guide/develop/publish.md"
-        }]
-      }, {
-        "text": "交互基础",
-        "items": [{
-          "text": "指令开发",
-          "link": "/guide/basic/command.md"
-        }, {
-          "text": "事件系统",
-          "link": "/guide/basic/events.md"
-        }, {
-          "text": "中间件",
-          "link": "/guide/basic/middleware.md"
-        }, {
+      "/manual/": [
+        {
+          "text": "",
+          "items": [
+            {
+              "text": "介绍",
+              "link": "/manual/introduction.md"
+            }
+          ]
+        },
+        {
+          "text": "",
+          "items": [
+            {
+              "text": "安装",
+              "link": "/manual/starter/"
+            },
+            {
+              "text": "为 Windows 安装",
+              "link": "/manual/starter/windows.md"
+            },
+            {
+              "text": "为 macOS 安装",
+              "link": "/manual/starter/macos.md"
+            },
+            {
+              "text": "为 Linux 安装",
+              "link": "/manual/starter/linux.md"
+            },
+            {
+              "text": "为 Android 安装",
+              "link": "/manual/starter/android.md"
+            },
+            {
+              "text": "在容器中使用",
+              "link": "/manual/starter/docker.md"
+            },
+            {
+              "text": "创建模板项目",
+              "link": "/manual/starter/boilerplate.md"
+            },
+            {
+              "text": "作为依赖调用",
+              "link": "/manual/starter/direct.md"
+            }
+          ]
+        },
+        {
+          "text": "使用",
+          "items": [
+            {
+              "text": "安装和配置插件",
+              "link": "/manual/usage/market.md"
+            },
+            {
+              "text": "第一次对话",
+              "link": "/manual/usage/adapter.md"
+            },
+            {
+              "text": "指令系统",
+              "link": "/manual/usage/command.md"
+            },
+            {
+              "text": "账号登录与绑定",
+              "link": "/manual/usage/platform.md"
+            },
+            {
+              "text": "深入定制机器人",
+              "link": "/manual/usage/customize.md"
+            }
+          ]
+        },
+        {
+          "text": "配方",
+          "items": [
+            {
+              "text": "指令进阶技巧",
+              "link": "/manual/recipe/execution.md"
+            },
+            {
+              "text": "维护多份配置",
+              "link": "/manual/recipe/multiple.md"
+            },
+            {
+              "text": "搜索插件市场",
+              "link": "/manual/recipe/search.md"
+            },
+            {
+              "text": "公网部署",
+              "link": "/manual/recipe/server.md"
+            }
+          ]
+        },
+        {
+          "text": "启动器",
+          "items": [
+            {
+              "text": "系统要求",
+              "link": "/manual/launcher/system.md"
+            },
+            {
+              "text": "命令行工具",
+              "link": "/manual/launcher/cli.md"
+            }
+          ]
+        }
+      ],
+      "/guide/": [
+        {
+          "text": "",
+          "items": [
+            {
+              "text": "总览",
+              "link": "/guide/"
+            }
+          ]
+        },
+        {
+          "text": "开发起步",
+          "items": [
+            {
+              "text": "环境搭建",
+              "link": "/guide/develop/setup.md"
+            },
+            {
+              "text": "配置文件",
+              "link": "/guide/develop/config.md"
+            },
+            {
+              "text": "启动脚本",
+              "link": "/guide/develop/script.md"
+            },
+            {
+              "text": "工作区开发",
+              "link": "/guide/develop/workspace.md"
+            },
+            {
+              "text": "发布插件",
+              "link": "/guide/develop/publish.md"
+            }
+          ]
+        },
+        {
+          "text": "交互基础",
+          "items": [
+            {
+              "text": "指令开发",
+              "link": "/guide/basic/command.md"
+            },
+            {
+              "text": "事件系统",
+              "link": "/guide/basic/events.md"
+            },
+            {
+              "text": "中间件",
+              "link": "/guide/basic/middleware.md"
+            },
+            {
+              "text": "消息元素",
+              "link": "/guide/basic/element.md"
+            },
+            {
+              "text": "进阶用法",
+              "link": "/guide/basic/advanced.md"
+            }
+          ]
+        },
+        {
+          "text": "模块化",
+          "items": [
+            {
+              "text": "认识插件",
+              "link": "/guide/plugin/"
+            },
+            {
+              "text": "配置构型",
+              "link": "/guide/plugin/schema.md"
+            },
+            {
+              "text": "生命周期",
+              "link": "/guide/plugin/lifecycle.md"
+            },
+            {
+              "text": "服务与依赖",
+              "link": "/guide/plugin/service.md"
+            },
+            {
+              "text": "过滤器",
+              "link": "/guide/plugin/filter.md"
+            }
+          ]
+        },
+        {
+          "text": "数据库",
+          "items": [
+            {
+              "text": "基本用法",
+              "link": "/guide/database/"
+            },
+            {
+              "text": "数据模型",
+              "link": "/guide/database/model.md"
+            },
+            {
+              "text": "进阶查询技巧",
+              "link": "/guide/database/selection.md"
+            },
+            {
+              "text": "内置数据结构",
+              "link": "/guide/database/builtin.md"
+            },
+            {
+              "text": "权限管理",
+              "link": "/guide/database/permission.md"
+            }
+          ]
+        },
+        {
+          "text": "跨平台",
+          "items": [
+            {
+              "text": "基础知识",
+              "link": "/guide/adapter/index.md"
+            },
+            {
+              "text": "实现机器人",
+              "link": "/guide/adapter/bot.md"
+            },
+            {
+              "text": "实现适配器",
+              "link": "/guide/adapter/adapter.md"
+            },
+            {
+              "text": "消息编码",
+              "link": "/guide/adapter/message.md"
+            },
+            {
+              "text": "平台集成",
+              "link": "/guide/adapter/integration.md"
+            }
+          ]
+        },
+        {
+          "text": "控制台",
+          "items": [
+            {
+              "text": "扩展控制台",
+              "link": "/guide/console/index.md"
+            },
+            {
+              "text": "数据交互",
+              "link": "/guide/console/data.md"
+            },
+            {
+              "text": "客户端开发",
+              "link": "/guide/console/client.md"
+            },
+            {
+              "text": "主题开发",
+              "link": "/guide/console/theme.md"
+            }
+          ]
+        },
+        {
+          "text": "国际化",
+          "items": [
+            {
+              "text": "基本用法",
+              "link": "/guide/i18n/index.md"
+            },
+            {
+              "text": "本地化文件",
+              "link": "/guide/i18n/translation.md"
+            },
+            {
+              "text": "语言包开发",
+              "link": "/guide/i18n/lang-pack.md"
+            },
+            {
+              "text": "接入 Crowdin",
+              "link": "/guide/i18n/crowdin.md"
+            }
+          ]
+        },
+        {
+          "items": [
+            {
+              "text": "→ 进阶指南",
+              "link": "/cookbook/"
+            }
+          ]
+        }
+      ],
+      "/api/": [
+        {
+          "text": "",
+          "items": [
+            {
+              "text": "总览",
+              "link": "/api/"
+            },
+            {
+              "text": "术语表",
+              "link": "/api/glossary.md"
+            }
+          ]
+        },
+        {
+          "text": "演练场",
+          "desc": "我们专门为一些 API 提供了交互式的演练场。",
+          "items": [
+            {
+              "text": "配置构型",
+              "link": "/schema/"
+            }
+          ]
+        },
+        {
+          "text": "核心模块",
+          "items": [
+            {
+              "text": "适配器 (Adapter)",
+              "link": "/api/core/adapter.md"
+            },
+            {
+              "text": "应用 (App)",
+              "link": "/api/core/app.md"
+            },
+            {
+              "text": "机器人 (Bot)",
+              "link": "/api/core/bot.md"
+            },
+            {
+              "text": "指令 (Command)",
+              "link": "/api/core/command.md"
+            },
+            {
+              "text": "上下文 (Context)",
+              "link": "/api/core/context.md"
+            },
+            {
+              "text": "事件 (Events)",
+              "link": "/api/core/events.md"
+            },
+            {
+              "text": "会话 (Session)",
+              "link": "/api/core/session.md"
+            }
+          ]
+        },
+        {
+          "text": "内置服务",
+          "items": [
+            {
+              "text": "事件系统 (Events)",
+              "link": "/api/service/events.md"
+            },
+            {
+              "text": "过滤器 (Filter)",
+              "link": "/api/service/filter.md"
+            },
+            {
+              "text": "网络请求 (HTTP)",
+              "link": "/api/service/http.md"
+            },
+            {
+              "text": "国际化 (I18n)",
+              "link": "/api/service/i18n.md"
+            },
+            {
+              "text": "加载器 (Loader)",
+              "link": "/api/service/loader.md"
+            },
+            {
+              "text": "权限管理 (Permissions)",
+              "link": "/api/service/permissions.md"
+            },
+            {
+              "text": "插件系统 (Registry)",
+              "link": "/api/service/registry.md"
+            },
+            {
+              "text": "服务器 (Server)",
+              "link": "/api/service/server.md"
+            },
+            {
+              "text": "计时器 (Timer)",
+              "link": "/api/service/timer.md"
+            }
+          ]
+        },
+        {
+          "text": "平台资源",
+          "items": [
+            {
+              "text": "频道 (Channel)",
+              "link": "/api/resources/channel.md"
+            },
+            {
+              "text": "群组 (Guild)",
+              "link": "/api/resources/guild.md"
+            },
+            {
+              "text": "群组成员 (GuildMember)",
+              "link": "/api/resources/member.md"
+            },
+            {
+              "text": "群组角色 (GuildRole)",
+              "link": "/api/resources/role.md"
+            },
+            {
+              "text": "交互 (Interaction)",
+              "link": "/api/resources/interaction.md"
+            },
+            {
+              "text": "登录状态 (Login)",
+              "link": "/api/resources/login.md"
+            },
+            {
+              "text": "消息 (Message)",
+              "link": "/api/resources/message.md"
+            },
+            {
+              "text": "表态 (Reaction)",
+              "link": "/api/resources/reaction.md"
+            },
+            {
+              "text": "用户 (User)",
+              "link": "/api/resources/user.md"
+            }
+          ]
+        },
+        {
           "text": "消息元素",
-          "link": "/guide/basic/element.md"
-        }, {
-          "text": "进阶用法",
-          "link": "/guide/basic/advanced.md"
-        }]
-      }, {
-        "text": "模块化",
-        "items": [{
-          "text": "认识插件",
-          "link": "/guide/plugin/"
-        }, {
-          "text": "配置构型",
-          "link": "/guide/plugin/schema.md"
-        }, {
-          "text": "生命周期",
-          "link": "/guide/plugin/lifecycle.md"
-        }, {
-          "text": "服务与依赖",
-          "link": "/guide/plugin/service.md"
-        }, {
-          "text": "过滤器",
-          "link": "/guide/plugin/filter.md"
-        }]
-      }, {
-        "text": "数据库",
-        "items": [{
-          "text": "基本用法",
-          "link": "/guide/database/"
-        }, {
-          "text": "数据模型",
-          "link": "/guide/database/model.md"
-        }, {
-          "text": "进阶查询技巧",
-          "link": "/guide/database/selection.md"
-        }, {
-          "text": "内置数据结构",
-          "link": "/guide/database/builtin.md"
-        }, {
-          "text": "权限管理",
-          "link": "/guide/database/permission.md"
-        }]
-      }, {
-        "text": "跨平台",
-        "items": [{
-          "text": "基础知识",
-          "link": "/guide/adapter/index.md"
-        }, {
-          "text": "实现机器人",
-          "link": "/guide/adapter/bot.md"
-        }, {
-          "text": "实现适配器",
-          "link": "/guide/adapter/adapter.md"
-        }, {
-          "text": "消息编码",
-          "link": "/guide/adapter/message.md"
-        }, {
-          "text": "平台集成",
-          "link": "/guide/adapter/integration.md"
-        }]
-      }, {
-        "text": "控制台",
-        "items": [{
-          "text": "扩展控制台",
-          "link": "/guide/console/index.md"
-        }, {
-          "text": "数据交互",
-          "link": "/guide/console/data.md"
-        }, {
-          "text": "客户端开发",
-          "link": "/guide/console/client.md"
-        }, {
-          "text": "主题开发",
-          "link": "/guide/console/theme.md"
-        }]
-      }, {
-        "text": "国际化",
-        "items": [{
-          "text": "基本用法",
-          "link": "/guide/i18n/index.md"
-        }, {
-          "text": "本地化文件",
-          "link": "/guide/i18n/translation.md"
-        }, {
-          "text": "语言包开发",
-          "link": "/guide/i18n/lang-pack.md"
-        }, {
-          "text": "接入 Crowdin",
-          "link": "/guide/i18n/crowdin.md"
-        }]
-      }, {
-        "items": [{
-          "text": "→ 进阶指南",
-          "link": "/cookbook/"
-        }]
-      }],
-      "/api/": [{
-        "text": "",
-        "items": [{
-          "text": "总览",
-          "link": "/api/"
-        }, {
-          "text": "术语表",
-          "link": "/api/glossary.md"
-        }]
-      }, {
-        "text": "演练场",
-        "desc": "我们专门为一些 API 提供了交互式的演练场。",
-        "items": [{
-          "text": "配置构型",
-          "link": "/schema/"
-        }]
-      }, {
-        "text": "核心模块",
-        "items": [{
-          "text": "适配器 (Adapter)",
-          "link": "/api/core/adapter.md"
-        }, {
-          "text": "应用 (App)",
-          "link": "/api/core/app.md"
-        }, {
-          "text": "机器人 (Bot)",
-          "link": "/api/core/bot.md"
-        }, {
-          "text": "指令 (Command)",
-          "link": "/api/core/command.md"
-        }, {
-          "text": "上下文 (Context)",
-          "link": "/api/core/context.md"
-        }, {
-          "text": "事件 (Events)",
-          "link": "/api/core/events.md"
-        }, {
-          "text": "会话 (Session)",
-          "link": "/api/core/session.md"
-        }]
-      }, {
-        "text": "内置服务",
-        "items": [{
-          "text": "事件系统 (Events)",
-          "link": "/api/service/events.md"
-        }, {
-          "text": "过滤器 (Filter)",
-          "link": "/api/service/filter.md"
-        }, {
-          "text": "网络请求 (HTTP)",
-          "link": "/api/service/http.md"
-        }, {
-          "text": "国际化 (I18n)",
-          "link": "/api/service/i18n.md"
-        }, {
-          "text": "加载器 (Loader)",
-          "link": "/api/service/loader.md"
-        }, {
-          "text": "权限管理 (Permissions)",
-          "link": "/api/service/permissions.md"
-        }, {
-          "text": "插件系统 (Registry)",
-          "link": "/api/service/registry.md"
-        }, {
-          "text": "服务器 (Server)",
-          "link": "/api/service/server.md"
-        }, {
-          "text": "计时器 (Timer)",
-          "link": "/api/service/timer.md"
-        }]
-      }, {
-        "text": "平台资源",
-        "items": [{
-          "text": "频道 (Channel)",
-          "link": "/api/resources/channel.md"
-        }, {
-          "text": "群组 (Guild)",
-          "link": "/api/resources/guild.md"
-        }, {
-          "text": "群组成员 (GuildMember)",
-          "link": "/api/resources/member.md"
-        }, {
-          "text": "群组角色 (GuildRole)",
-          "link": "/api/resources/role.md"
-        }, {
-          "text": "交互 (Interaction)",
-          "link": "/api/resources/interaction.md"
-        }, {
-          "text": "登录状态 (Login)",
-          "link": "/api/resources/login.md"
-        }, {
-          "text": "消息 (Message)",
-          "link": "/api/resources/message.md"
-        }, {
-          "text": "表态 (Reaction)",
-          "link": "/api/resources/reaction.md"
-        }, {
-          "text": "用户 (User)",
-          "link": "/api/resources/user.md"
-        }]
-      }, {
-        "text": "消息元素",
-        "items": [{
-          "text": "语法规范",
-          "link": "/api/message/syntax.md"
-        }, {
-          "text": "标准元素",
-          "link": "/api/message/elements.md"
-        }, {
-          "text": "内置组件",
-          "link": "/api/message/components.md"
-        }, {
-          "text": "渲染函数",
-          "link": "/api/message/api.md"
-        }, {
-          "text": "消息编码器",
-          "link": "/api/message/encoder.md"
-        }]
-      }, {
-        "text": "数据库",
-        "items": [{
-          "text": "数据模型 (Model)",
-          "link": "/api/database/model.md"
-        }, {
-          "text": "数据库操作 (Database)",
-          "link": "/api/database/database.md"
-        }, {
-          "text": "查询表达式 (Query)",
-          "link": "/api/database/query.md"
-        }, {
-          "text": "求值表达式 (Eval)",
-          "link": "/api/database/evaluation.md"
-        }, {
-          "text": "查询构造器 (Selection)",
-          "link": "/api/database/selection.md"
-        }, {
-          "text": "内置数据结构",
-          "link": "/api/database/built-in.md"
-        }]
-      }, {
-        "text": "控制台",
-        "items": [{
-          "text": "服务端 API",
-          "link": "/api/console/server.md"
-        }, {
-          "text": "上下文 API",
-          "link": "/api/console/context.md"
-        }, {
-          "text": "组合式 API",
-          "link": "/api/console/composition.md"
-        }, {
-          "text": "内置组件",
-          "link": "/api/console/component.md"
-        }]
-      }, {
-        "text": "其他功能",
-        "items": [{
-          "text": "观察者 (Observer)",
-          "link": "/api/utils/observer.md"
-        }, {
-          "text": "输出日志 (Logger)",
-          "link": "/api/utils/logger.md"
-        }, {
-          "text": "随机操作 (Random)",
-          "link": "/api/utils/random.md"
-        }, {
-          "text": "其他工具 (Misc)",
-          "link": "/api/utils/misc.md"
-        }]
-      }],
-      "/cookbook/": [{
-        "items": [{
-          "text": "总览",
-          "link": "/cookbook/"
-        }]
-      }, {
-        "text": "设计原理",
-        "items": [{
-          "text": "项目架构",
-          "link": "/cookbook/design/structure.md"
-        }, {
-          "text": "可逆的插件系统",
-          "link": "/cookbook/design/disposable.md"
-        }, {
-          "text": "从元框架到框架",
-          "link": "/cookbook/design/framework.md"
-        }, {
-          "text": "零占用的存储",
-          "link": "/cookbook/design/storage.md"
-        }, {
-          "text": "深入工作区",
-          "link": "/cookbook/design/workspace.md"
-        }]
-      }, {
-        "text": "最佳实践",
-        "items": [{
-          "text": "资源转存",
-          "link": "/cookbook/practice/assets.md"
-        }, {
-          "text": "图片渲染",
-          "link": "/cookbook/practice/render.md"
-        }, {
-          "text": "部署到 k-on!",
-          "link": "/cookbook/practice/online.md"
-        }, {
-          "text": "整合包开发",
-          "link": "/cookbook/practice/bundle.md"
-        }, {
-          "text": "编写测试",
-          "link": "/cookbook/practice/testing.md"
-        }]
-      }, {
-        "text": "案例分析",
-        "items": [{
-          "text": "指令管理",
-          "link": "/cookbook/appendix/commands.md"
-        }]
-      }],
-      "/plugins/": [{
-        "text": "插件",
-        "items": [{
-          "text": "插件市场",
-          "link": "/market/"
-        }, {
-          "text": "官方插件一览",
-          "link": "/plugins/"
-        }]
-      }, {
-        "text": "适配器支持",
-        "items": [{
-          "text": "钉钉",
-          "link": "/plugins/adapter/dingtalk.md"
-        }, {
-          "text": "Discord",
-          "link": "/plugins/adapter/discord.md"
-        }, {
-          "text": "Kook",
-          "link": "/plugins/adapter/kook.md"
-        }, {
-          "text": "飞书",
-          "link": "/plugins/adapter/lark.md"
-        }, {
-          "text": "LINE",
-          "link": "/plugins/adapter/line.md"
-        }, {
-          "text": "邮件",
-          "link": "/plugins/adapter/mail.md"
-        }, {
-          "text": "Matrix",
-          "link": "/plugins/adapter/matrix.md"
-        }, {
-          "text": "QQ",
-          "link": "/plugins/adapter/qq.md"
-        }, {
-          "text": "Satori",
-          "link": "/plugins/adapter/satori.md"
-        }, {
-          "text": "Slack",
-          "link": "/plugins/adapter/slack.md"
-        }, {
-          "text": "Telegram",
-          "link": "/plugins/adapter/telegram.md"
-        }, {
-          "text": "微信公众号",
-          "link": "/plugins/adapter/wechat-official.md"
-        }, {
-          "text": "企业微信",
-          "link": "/plugins/adapter/wecom.md"
-        }, {
-          "text": "WhatsApp",
-          "link": "/plugins/adapter/whatsapp.md"
-        }, {
-          "text": "Zulip",
-          "link": "/plugins/adapter/zulip.md"
-        }]
-      }, {
-        "text": "数据库支持",
-        "items": [{
-          "text": "Memory",
-          "link": "/plugins/database/memory.md"
-        }, {
-          "text": "MongoDB",
-          "link": "/plugins/database/mongo.md"
-        }, {
-          "text": "MySQL / MariaDB",
-          "link": "/plugins/database/mysql.md"
-        }, {
-          "text": "PostgreSQL",
-          "link": "/plugins/database/postgres.md"
-        }, {
-          "text": "SQLite",
-          "link": "/plugins/database/sqlite.md"
-        }]
-      }, {
-        "text": "常用功能",
-        "items": [{
-          "text": "数据管理 (Admin)",
-          "link": "/plugins/common/admin.md"
-        }, {
-          "text": "账号绑定 (Bind)",
-          "link": "/plugins/common/bind.md"
-        }, {
-          "text": "发送广播 (Broadcast)",
-          "link": "/plugins/common/broadcast.md"
-        }, {
-          "text": "设置昵称 (Callme)",
-          "link": "/plugins/common/callme.md"
-        }, {
-          "text": "发送消息 (Echo)",
-          "link": "/plugins/common/echo.md"
-        }, {
-          "text": "查看帮助 (Help)",
-          "link": "/plugins/common/help.md"
-        }, {
-          "text": "会话信息 (Inspect)",
-          "link": "/plugins/common/inspect.md"
-        }]
-      }, {
-        "text": "控制台功能",
-        "items": [{
-          "text": "数据统计 (Analytics)",
-          "link": "/plugins/console/analytics.md"
-        }, {
-          "text": "用户登录 (Auth)",
-          "link": "/plugins/console/auth.md"
-        }, {
-          "text": "指令管理 (Commands)",
-          "link": "/plugins/console/commands.md"
-        }, {
-          "text": "插件配置 (Config)",
-          "link": "/plugins/console/config.md"
-        }, {
-          "text": "控制台 (Console)",
-          "link": "/plugins/console/index.md"
-        }, {
-          "text": "资源管理器 (Explorer)",
-          "link": "/plugins/console/explorer.md"
-        }, {
-          "text": "插件依赖图 (Insight)",
-          "link": "/plugins/console/insight.md"
-        }, {
-          "text": "本地翻译 (Locales)",
-          "link": "/plugins/console/locales.md"
-        }, {
-          "text": "日志管理 (Logger)",
-          "link": "/plugins/console/logger.md"
-        }, {
-          "text": "插件市场 (Market)",
-          "link": "/plugins/console/market.md"
-        }, {
-          "text": "沙箱调试 (Sandbox)",
-          "link": "/plugins/console/sandbox.md"
-        }, {
-          "text": "运行状态 (Status)",
-          "link": "/plugins/console/status.md"
-        }]
-      }, {
-        "text": "开发工具",
-        "items": [{
-          "text": "模块热替换 (HMR)",
-          "link": "/plugins/develop/hmr.md"
-        }, {
-          "text": "网络请求 (HTTP)",
-          "link": "/plugins/develop/http.md"
-        }, {
-          "text": "测试工具 (Mock)",
-          "link": "/plugins/develop/mock.md"
-        }, {
-          "text": "通知服务 (Notifier)",
-          "link": "/plugins/develop/notifier.md"
-        }, {
-          "text": "网络代理 (Proxy Agent)",
-          "link": "/plugins/develop/proxy-agent.md"
-        }, {
-          "text": "服务器 (Server)",
-          "link": "/plugins/develop/server.md"
-        }, {
-          "text": "API 服务器 (Server Satori)",
-          "link": "/plugins/develop/server-satori.md"
-        }, {
-          "text": "临时服务器 (Server Temp)",
-          "link": "/plugins/develop/server-temp.md"
-        }]
-      }],
-      "/market/": [{
-        "text": "插件",
-        "items": [{
-          "text": "插件市场",
-          "link": "/market/"
-        }, {
-          "text": "官方插件一览",
-          "link": "/plugins/"
-        }]
-      }],
-      "/schema/": [{
-        "text": "演练场",
-        "items": [{
-          "text": "配置构型",
-          "link": "/schema/index.md"
-          }]
-      }, {
-        "text": "核心概念",
-        "items": [{
-          "text": "必需与可选",
-          "link": "/schema/meta/required.md"
-        }, {
-          "text": "默认值",
-          "link": "/schema/meta/default.md"
-        }, {
-          "text": "标题与描述",
-          "link": "/schema/meta/description.md"
-        }, {
-          "text": "禁用与隐藏",
-          "link": "/schema/meta/disabled.md"
-        }, {
-          "text": "配置项外观",
-          "link": "/schema/meta/role.md"
-        }, {
-          "text": "嵌套类型",
-          "link": "/schema/meta/nested.md"
-        }]
-      }, {
-        "text": "基础类型",
-        "items": [{
-          "text": "数值 (Number)",
-          "link": "/schema/basic/number.md"
-        }, {
-          "text": "字符串 (String)",
-          "link": "/schema/basic/string.md"
-        }, {
-          "text": "布尔值 (Boolean)",
-          "link": "/schema/basic/boolean.md"
-        }, {
-          "text": "日期 (Date)",
-          "link": "/schema/basic/date.md"
-        }, {
-          "text": "位集 (Bitset)",
-          "link": "/schema/basic/bitset.md"
-        }, {
-          "text": "对象 (Object)",
-          "link": "/schema/basic/object.md"
-        }, {
-          "text": "元组 (Tuple)",
-          "link": "/schema/basic/tuple.md"
-        }, {
-          "text": "字典 (Dict)",
-          "link": "/schema/basic/dict.md"
-        }, {
-          "text": "数组 (Array)",
-          "link": "/schema/basic/array.md"
-        }, {
-          "text": "路径 (Path)",
-          "link": "/schema/basic/path.md"
-        }]
-      }, {
-        "text": "高级类型",
-        "items": [{
-          "text": "Intersect：分组",
-          "link": "/schema/advanced/intersect.md"
-        }, {
-          "text": "Union：单选框",
-          "link": "/schema/advanced/union-select.md"
-        }, {
-          "text": "Union：联合类型",
-          "link": "/schema/advanced/union-arbitrary.md"
-        }, {
-          "text": "Intersect + Union：配置联动 1",
-          "link": "/schema/advanced/union-tagged-1.md"
-        }, {
-          "text": "Intersect + Union：配置联动 2",
-          "link": "/schema/advanced/union-tagged-2.md"
-        }, {
-          "text": "Transform：输入转换",
-          "link": "/schema/advanced/transform.md"
-        }, {
-          "text": "Computed：条件求值",
-          "link": "/schema/advanced/computed.md"
-        }]
-      }],
-      "/about/": [{
-        "text": "关于",
-        "items": [{
-          "text": "许可证",
-          "link": "/about/license.md"
-        }, {
-          "text": "参与讨论",
-          "link": "/about/contact.md"
-        }, {
-          "text": "认识团队",
-          "link": "/about/team.md"
-        }, {
-          "text": "常见问题",
-          "link": "/about/faq.md"
-        }, {
-          "text": "社区资源",
-          "link": "/about/community.md"
-        }, {
-          "text": "大事件",
-          "link": "/about/events.md"
-        }]
-      }, {
-        "text": "更新",
-        "items": [{
-          "text": "发展史",
-          "link": "/about/history.md"
-        }, {
-          "text": "更新计划",
-          "link": "/about/releases.md"
-        }, {
-          "text": "从低版本迁移",
-          "link": "/about/upgrade.md"
-        }, {
-          "text": "各版本介绍",
-          "link": "/releases/index.md"
-        }, {
-          "text": "更新日志",
-          "link": "https://github.com/koishijs/koishi/releases"
-        }]
-      }, {
-        "text": "贡献",
-        "items": [{
-          "text": "项目结构",
-          "link": "/about/contribute/structure.md"
-        }, {
-          "text": "文档贡献指南",
-          "link": "/about/contribute/docs.md"
-        }]
-      }],
-      "/releases": [{
-        "text": "",
-        "items": [{
-          "text": "各版本介绍",
-          "link": "/releases/index.md"
-        }, {
-          "text": "v4.1 版本介绍",
-          "link": "/releases/v4.1.md"
-        }, {
-          "text": "v4.2 版本介绍",
-          "link": "/releases/v4.2.md"
-        }, {
-          "text": "v4.3 版本介绍",
-          "link": "/releases/v4.3.md"
-        }, {
-          "text": "v4.4 版本介绍",
-          "link": "/releases/v4.4.md"
-        }, {
-          "text": "v4.5 版本介绍",
-          "link": "/releases/v4.5.md"
-        }, {
-          "text": "v4.6 版本介绍",
-          "link": "/releases/v4.6.md"
-        }, {
-          "text": "v4.7 版本介绍",
-          "link": "/releases/v4.7.md"
-        }, {
-          "text": "v4.8 版本介绍",
-          "link": "/releases/v4.8.md"
-        }, {
-          "text": "v4.9 版本介绍",
-          "link": "/releases/v4.9.md"
-        }, {
-          "text": "v4.10 版本介绍",
-          "link": "/releases/v4.10.md"
-        }, {
-          "text": "v4.11 版本介绍",
-          "link": "/releases/v4.11.md"
-        }, {
-          "text": "v4.12 版本介绍",
-          "link": "/releases/v4.12.md"
-        }, {
-          "text": "v4.13 版本介绍",
-          "link": "/releases/v4.13.md"
-        }, {
-          "text": "v4.14 版本介绍",
-          "link": "/releases/v4.14.md"
-        }, {
-          "text": "v4.15 版本介绍",
-          "link": "/releases/v4.15.md"
-        }]
-      }, {
-        "text": "",
-        "items": [{
-          "text": "更新日志",
-          "link": "https://github.com/koishijs/koishi/releases"
-        }]
-      }]
+          "items": [
+            {
+              "text": "语法规范",
+              "link": "/api/message/syntax.md"
+            },
+            {
+              "text": "标准元素",
+              "link": "/api/message/elements.md"
+            },
+            {
+              "text": "内置组件",
+              "link": "/api/message/components.md"
+            },
+            {
+              "text": "渲染函数",
+              "link": "/api/message/api.md"
+            },
+            {
+              "text": "消息编码器",
+              "link": "/api/message/encoder.md"
+            }
+          ]
+        },
+        {
+          "text": "数据库",
+          "items": [
+            {
+              "text": "数据模型 (Model)",
+              "link": "/api/database/model.md"
+            },
+            {
+              "text": "数据库操作 (Database)",
+              "link": "/api/database/database.md"
+            },
+            {
+              "text": "查询表达式 (Query)",
+              "link": "/api/database/query.md"
+            },
+            {
+              "text": "求值表达式 (Eval)",
+              "link": "/api/database/evaluation.md"
+            },
+            {
+              "text": "查询构造器 (Selection)",
+              "link": "/api/database/selection.md"
+            },
+            {
+              "text": "内置数据结构",
+              "link": "/api/database/built-in.md"
+            }
+          ]
+        },
+        {
+          "text": "控制台",
+          "items": [
+            {
+              "text": "服务端 API",
+              "link": "/api/console/server.md"
+            },
+            {
+              "text": "上下文 API",
+              "link": "/api/console/context.md"
+            },
+            {
+              "text": "组合式 API",
+              "link": "/api/console/composition.md"
+            },
+            {
+              "text": "内置组件",
+              "link": "/api/console/component.md"
+            }
+          ]
+        },
+        {
+          "text": "其他功能",
+          "items": [
+            {
+              "text": "观察者 (Observer)",
+              "link": "/api/utils/observer.md"
+            },
+            {
+              "text": "输出日志 (Logger)",
+              "link": "/api/utils/logger.md"
+            },
+            {
+              "text": "随机操作 (Random)",
+              "link": "/api/utils/random.md"
+            },
+            {
+              "text": "其他工具 (Misc)",
+              "link": "/api/utils/misc.md"
+            }
+          ]
+        }
+      ],
+      "/cookbook/": [
+        {
+          "items": [
+            {
+              "text": "总览",
+              "link": "/cookbook/"
+            }
+          ]
+        },
+        {
+          "text": "设计原理",
+          "items": [
+            {
+              "text": "项目架构",
+              "link": "/cookbook/design/structure.md"
+            },
+            {
+              "text": "可逆的插件系统",
+              "link": "/cookbook/design/disposable.md"
+            },
+            {
+              "text": "从元框架到框架",
+              "link": "/cookbook/design/framework.md"
+            },
+            {
+              "text": "零占用的存储",
+              "link": "/cookbook/design/storage.md"
+            },
+            {
+              "text": "深入工作区",
+              "link": "/cookbook/design/workspace.md"
+            }
+          ]
+        },
+        {
+          "text": "最佳实践",
+          "items": [
+            {
+              "text": "资源转存",
+              "link": "/cookbook/practice/assets.md"
+            },
+            {
+              "text": "图片渲染",
+              "link": "/cookbook/practice/render.md"
+            },
+            {
+              "text": "部署到 k-on!",
+              "link": "/cookbook/practice/online.md"
+            },
+            {
+              "text": "整合包开发",
+              "link": "/cookbook/practice/bundle.md"
+            },
+            {
+              "text": "编写测试",
+              "link": "/cookbook/practice/testing.md"
+            }
+          ]
+        },
+        {
+          "text": "案例分析",
+          "items": [
+            {
+              "text": "指令管理",
+              "link": "/cookbook/appendix/commands.md"
+            }
+          ]
+        }
+      ],
+      "/plugins/": [
+        {
+          "text": "插件",
+          "items": [
+            {
+              "text": "插件市场",
+              "link": "/market/"
+            },
+            {
+              "text": "官方插件一览",
+              "link": "/plugins/"
+            }
+          ]
+        },
+        {
+          "text": "适配器支持",
+          "items": [
+            {
+              "text": "钉钉",
+              "link": "/plugins/adapter/dingtalk.md"
+            },
+            {
+              "text": "Discord",
+              "link": "/plugins/adapter/discord.md"
+            },
+            {
+              "text": "Kook",
+              "link": "/plugins/adapter/kook.md"
+            },
+            {
+              "text": "飞书",
+              "link": "/plugins/adapter/lark.md"
+            },
+            {
+              "text": "LINE",
+              "link": "/plugins/adapter/line.md"
+            },
+            {
+              "text": "邮件",
+              "link": "/plugins/adapter/mail.md"
+            },
+            {
+              "text": "Matrix",
+              "link": "/plugins/adapter/matrix.md"
+            },
+            {
+              "text": "QQ",
+              "link": "/plugins/adapter/qq.md"
+            },
+            {
+              "text": "Satori",
+              "link": "/plugins/adapter/satori.md"
+            },
+            {
+              "text": "Slack",
+              "link": "/plugins/adapter/slack.md"
+            },
+            {
+              "text": "Telegram",
+              "link": "/plugins/adapter/telegram.md"
+            },
+            {
+              "text": "微信公众号",
+              "link": "/plugins/adapter/wechat-official.md"
+            },
+            {
+              "text": "企业微信",
+              "link": "/plugins/adapter/wecom.md"
+            },
+            {
+              "text": "WhatsApp",
+              "link": "/plugins/adapter/whatsapp.md"
+            },
+            {
+              "text": "Zulip",
+              "link": "/plugins/adapter/zulip.md"
+            }
+          ]
+        },
+        {
+          "text": "数据库支持",
+          "items": [
+            {
+              "text": "Memory",
+              "link": "/plugins/database/memory.md"
+            },
+            {
+              "text": "MongoDB",
+              "link": "/plugins/database/mongo.md"
+            },
+            {
+              "text": "MySQL / MariaDB",
+              "link": "/plugins/database/mysql.md"
+            },
+            {
+              "text": "PostgreSQL",
+              "link": "/plugins/database/postgres.md"
+            },
+            {
+              "text": "SQLite",
+              "link": "/plugins/database/sqlite.md"
+            }
+          ]
+        },
+        {
+          "text": "常用功能",
+          "items": [
+            {
+              "text": "数据管理 (Admin)",
+              "link": "/plugins/common/admin.md"
+            },
+            {
+              "text": "账号绑定 (Bind)",
+              "link": "/plugins/common/bind.md"
+            },
+            {
+              "text": "发送广播 (Broadcast)",
+              "link": "/plugins/common/broadcast.md"
+            },
+            {
+              "text": "设置昵称 (Callme)",
+              "link": "/plugins/common/callme.md"
+            },
+            {
+              "text": "发送消息 (Echo)",
+              "link": "/plugins/common/echo.md"
+            },
+            {
+              "text": "查看帮助 (Help)",
+              "link": "/plugins/common/help.md"
+            },
+            {
+              "text": "会话信息 (Inspect)",
+              "link": "/plugins/common/inspect.md"
+            }
+          ]
+        },
+        {
+          "text": "控制台功能",
+          "items": [
+            {
+              "text": "数据统计 (Analytics)",
+              "link": "/plugins/console/analytics.md"
+            },
+            {
+              "text": "用户登录 (Auth)",
+              "link": "/plugins/console/auth.md"
+            },
+            {
+              "text": "指令管理 (Commands)",
+              "link": "/plugins/console/commands.md"
+            },
+            {
+              "text": "插件配置 (Config)",
+              "link": "/plugins/console/config.md"
+            },
+            {
+              "text": "控制台 (Console)",
+              "link": "/plugins/console/index.md"
+            },
+            {
+              "text": "资源管理器 (Explorer)",
+              "link": "/plugins/console/explorer.md"
+            },
+            {
+              "text": "插件依赖图 (Insight)",
+              "link": "/plugins/console/insight.md"
+            },
+            {
+              "text": "本地翻译 (Locales)",
+              "link": "/plugins/console/locales.md"
+            },
+            {
+              "text": "日志管理 (Logger)",
+              "link": "/plugins/console/logger.md"
+            },
+            {
+              "text": "插件市场 (Market)",
+              "link": "/plugins/console/market.md"
+            },
+            {
+              "text": "沙箱调试 (Sandbox)",
+              "link": "/plugins/console/sandbox.md"
+            },
+            {
+              "text": "运行状态 (Status)",
+              "link": "/plugins/console/status.md"
+            }
+          ]
+        },
+        {
+          "text": "开发工具",
+          "items": [
+            {
+              "text": "模块热替换 (HMR)",
+              "link": "/plugins/develop/hmr.md"
+            },
+            {
+              "text": "网络请求 (HTTP)",
+              "link": "/plugins/develop/http.md"
+            },
+            {
+              "text": "测试工具 (Mock)",
+              "link": "/plugins/develop/mock.md"
+            },
+            {
+              "text": "通知服务 (Notifier)",
+              "link": "/plugins/develop/notifier.md"
+            },
+            {
+              "text": "网络代理 (Proxy Agent)",
+              "link": "/plugins/develop/proxy-agent.md"
+            },
+            {
+              "text": "服务器 (Server)",
+              "link": "/plugins/develop/server.md"
+            },
+            {
+              "text": "API 服务器 (Server Satori)",
+              "link": "/plugins/develop/server-satori.md"
+            },
+            {
+              "text": "临时服务器 (Server Temp)",
+              "link": "/plugins/develop/server-temp.md"
+            }
+          ]
+        }
+      ],
+      "/market/": [
+        {
+          "text": "插件",
+          "items": [
+            {
+              "text": "插件市场",
+              "link": "/market/"
+            },
+            {
+              "text": "官方插件一览",
+              "link": "/plugins/"
+            }
+          ]
+        }
+      ],
+      "/schema/": [
+        {
+          "text": "演练场",
+          "items": [
+            {
+              "text": "配置构型",
+              "link": "/schema/index.md"
+            }
+          ]
+        },
+        {
+          "text": "核心概念",
+          "items": [
+            {
+              "text": "必需与可选",
+              "link": "/schema/meta/required.md"
+            },
+            {
+              "text": "默认值",
+              "link": "/schema/meta/default.md"
+            },
+            {
+              "text": "标题与描述",
+              "link": "/schema/meta/description.md"
+            },
+            {
+              "text": "禁用与隐藏",
+              "link": "/schema/meta/disabled.md"
+            },
+            {
+              "text": "配置项外观",
+              "link": "/schema/meta/role.md"
+            },
+            {
+              "text": "嵌套类型",
+              "link": "/schema/meta/nested.md"
+            }
+          ]
+        },
+        {
+          "text": "基础类型",
+          "items": [
+            {
+              "text": "数值 (Number)",
+              "link": "/schema/basic/number.md"
+            },
+            {
+              "text": "字符串 (String)",
+              "link": "/schema/basic/string.md"
+            },
+            {
+              "text": "布尔值 (Boolean)",
+              "link": "/schema/basic/boolean.md"
+            },
+            {
+              "text": "日期 (Date)",
+              "link": "/schema/basic/date.md"
+            },
+            {
+              "text": "位集 (Bitset)",
+              "link": "/schema/basic/bitset.md"
+            },
+            {
+              "text": "对象 (Object)",
+              "link": "/schema/basic/object.md"
+            },
+            {
+              "text": "元组 (Tuple)",
+              "link": "/schema/basic/tuple.md"
+            },
+            {
+              "text": "字典 (Dict)",
+              "link": "/schema/basic/dict.md"
+            },
+            {
+              "text": "数组 (Array)",
+              "link": "/schema/basic/array.md"
+            },
+            {
+              "text": "路径 (Path)",
+              "link": "/schema/basic/path.md"
+            }
+          ]
+        },
+        {
+          "text": "高级类型",
+          "items": [
+            {
+              "text": "Intersect：分组",
+              "link": "/schema/advanced/intersect.md"
+            },
+            {
+              "text": "Union：单选框",
+              "link": "/schema/advanced/union-select.md"
+            },
+            {
+              "text": "Union：联合类型",
+              "link": "/schema/advanced/union-arbitrary.md"
+            },
+            {
+              "text": "Intersect + Union：配置联动 1",
+              "link": "/schema/advanced/union-tagged-1.md"
+            },
+            {
+              "text": "Intersect + Union：配置联动 2",
+              "link": "/schema/advanced/union-tagged-2.md"
+            },
+            {
+              "text": "Transform：输入转换",
+              "link": "/schema/advanced/transform.md"
+            },
+            {
+              "text": "Computed：条件求值",
+              "link": "/schema/advanced/computed.md"
+            }
+          ]
+        }
+      ],
+      "/about/": [
+        {
+          "text": "关于",
+          "items": [
+            {
+              "text": "许可证",
+              "link": "/about/license.md"
+            },
+            {
+              "text": "参与讨论",
+              "link": "/about/contact.md"
+            },
+            {
+              "text": "认识团队",
+              "link": "/about/team.md"
+            },
+            {
+              "text": "常见问题",
+              "link": "/about/faq.md"
+            },
+            {
+              "text": "社区资源",
+              "link": "/about/community.md"
+            },
+            {
+              "text": "大事件",
+              "link": "/about/events.md"
+            }
+          ]
+        },
+        {
+          "text": "更新",
+          "items": [
+            {
+              "text": "发展史",
+              "link": "/about/history.md"
+            },
+            {
+              "text": "更新计划",
+              "link": "/about/releases.md"
+            },
+            {
+              "text": "从低版本迁移",
+              "link": "/about/upgrade.md"
+            },
+            {
+              "text": "各版本介绍",
+              "link": "/releases/index.md"
+            },
+            {
+              "text": "更新日志",
+              "link": "https://github.com/koishijs/koishi/releases"
+            }
+          ]
+        },
+        {
+          "text": "贡献",
+          "items": [
+            {
+              "text": "项目结构",
+              "link": "/about/contribute/structure.md"
+            },
+            {
+              "text": "文档贡献指南",
+              "link": "/about/contribute/docs.md"
+            }
+          ]
+        }
+      ],
+      "/releases": [
+        {
+          "text": "",
+          "items": [
+            {
+              "text": "各版本介绍",
+              "link": "/releases/index.md"
+            },
+            {
+              "text": "v4.1 版本介绍",
+              "link": "/releases/v4.1.md"
+            },
+            {
+              "text": "v4.2 版本介绍",
+              "link": "/releases/v4.2.md"
+            },
+            {
+              "text": "v4.3 版本介绍",
+              "link": "/releases/v4.3.md"
+            },
+            {
+              "text": "v4.4 版本介绍",
+              "link": "/releases/v4.4.md"
+            },
+            {
+              "text": "v4.5 版本介绍",
+              "link": "/releases/v4.5.md"
+            },
+            {
+              "text": "v4.6 版本介绍",
+              "link": "/releases/v4.6.md"
+            },
+            {
+              "text": "v4.7 版本介绍",
+              "link": "/releases/v4.7.md"
+            },
+            {
+              "text": "v4.8 版本介绍",
+              "link": "/releases/v4.8.md"
+            },
+            {
+              "text": "v4.9 版本介绍",
+              "link": "/releases/v4.9.md"
+            },
+            {
+              "text": "v4.10 版本介绍",
+              "link": "/releases/v4.10.md"
+            },
+            {
+              "text": "v4.11 版本介绍",
+              "link": "/releases/v4.11.md"
+            },
+            {
+              "text": "v4.12 版本介绍",
+              "link": "/releases/v4.12.md"
+            },
+            {
+              "text": "v4.13 版本介绍",
+              "link": "/releases/v4.13.md"
+            },
+            {
+              "text": "v4.14 版本介绍",
+              "link": "/releases/v4.14.md"
+            },
+            {
+              "text": "v4.15 版本介绍",
+              "link": "/releases/v4.15.md"
+            }
+          ]
+        },
+        {
+          "text": "",
+          "items": [
+            {
+              "text": "更新日志",
+              "link": "https://github.com/koishijs/koishi/releases"
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/.vitepress/config/zh-TW.json
+++ b/.vitepress/config/zh-TW.json
@@ -967,6 +967,10 @@
               "link": "/schema/basic/boolean.md"
             },
             {
+              "text": "日期 (Date)",
+              "link": "/schema/basic/date.md"
+            },
+            {
               "text": "位集 (Bitset)",
               "link": "/schema/basic/bitset.md"
             },


### PR DESCRIPTION

- 补全 `.vitepress/config/*.json` 的配置构型缺失date页面
- 格式化 `.vitepress/config/zh-CN.json` ，与其他语言的json格式一致