### PR TITLE
fix: 简体中文文档 `实现适配器` 的 `polling.ts` 中, `protocol` 不正确

### DIFF
--- a/zh-CN/guide/adapter/adapter.md
+++ b/zh-CN/guide/adapter/adapter.md
@@ -208,7 +208,7 @@ namespace PollingAdapter {
   }
 
   export const Options: Schema<Options> = Schema.object({
-    protocol: Schema.const('server').required(),
+    protocol: Schema.const('polling').required(),
     timeout: Schema.number().default(Time.second * 25),
   })
 }


### PR DESCRIPTION
…erver` 而非 `polling`